### PR TITLE
Wrapper for GL_TEXTURE_2D_ARRAY, could be extended with more

### DIFF
--- a/include/ghoul/opengl/texturearray.h
+++ b/include/ghoul/opengl/texturearray.h
@@ -1,0 +1,66 @@
+/*****************************************************************************************
+*                                                                                       *
+* GHOUL                                                                                 *
+* General Helpful Open Utility Library                                                  *
+*                                                                                       *
+* Copyright (c) 2012-2017                                                               *
+*                                                                                       *
+* Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+* software and associated documentation files (the "Software"), to deal in the Software *
+* without restriction, including without limitation the rights to use, copy, modify,    *
+* merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+* permit persons to whom the Software is furnished to do so, subject to the following   *
+* conditions:                                                                           *
+*                                                                                       *
+* The above copyright notice and this permission notice shall be included in all copies *
+* or substantial portions of the Software.                                              *
+*                                                                                       *
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+* PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+* HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+* CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+* OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+****************************************************************************************/
+
+#ifndef __GHOUL___TEXTURE_ARRAY___H__
+#define __GHOUL___TEXTURE_ARRAY___H__
+
+#include <ghoul/opengl/ghoul_gl.h>
+#include <ghoul/glm.h>
+
+namespace ghoul {
+namespace opengl {
+
+
+class TextureArray {
+public:
+	TextureArray(glm::uvec3 dimensions, int size, 
+		GLint format = GL_RGBA, GLint internalFormat = GL_RGBA8, GLenum dataType = GL_UNSIGNED_BYTE, 
+		bool allocateData = true);
+
+	//~TextureArray();
+	
+	void setType(GLenum type);
+	void uploadTexture(const void* pixels);
+	void allocateMemory();
+	void determineTextureType();
+
+	void bind() const;
+
+	GLuint id();
+
+private:
+	glm::uvec3 _dimensions;
+	int _counter;
+	int _size;
+	GLuint _id, _format, _internalFormat;
+	GLenum _type, _dataType;
+
+	void generateId();
+	void initialize(bool allocateData);
+};
+}
+}
+
+#endif //__GHOUL___TEXTURE_ARRAY___H__

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,7 @@
 # OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         #
 #########################################################################################
 
-set(GHOUL_SOURCE 
+set(GHOUL_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cmdparser/commandlinecommand.cpp
     ${PROJECT_SOURCE_DIR}/src/cmdparser/commandlineparser.cpp
     ${PROJECT_SOURCE_DIR}/src/cmdparser/multiplecommand.cpp
@@ -109,11 +109,12 @@ if (GHOUL_MODULE_OPENGL)
         ${PROJECT_SOURCE_DIR}/src/opengl/textureconversion.cpp
         ${PROJECT_SOURCE_DIR}/src/opengl/texturemanager.cpp
         ${PROJECT_SOURCE_DIR}/src/opengl/textureunit.cpp
+        ${PROJECT_SOURCE_DIR}/src/opengl/texturearray.cpp
         ${PROJECT_SOURCE_DIR}/src/opengl/vertexbufferobject.cpp
     )
 endif ()
 
-set(GHOUL_HEADER 
+set(GHOUL_HEADER
     ${PROJECT_SOURCE_DIR}/include/ghoul/cmdparser/cmdparser
     ${PROJECT_SOURCE_DIR}/include/ghoul/cmdparser/commandlinecommand.h
     ${PROJECT_SOURCE_DIR}/include/ghoul/cmdparser/commandlinecommand.inl
@@ -228,6 +229,7 @@ if (GHOUL_MODULE_OPENGL)
         ${PROJECT_SOURCE_DIR}/include/ghoul/opengl/texture.inl
         ${PROJECT_SOURCE_DIR}/include/ghoul/opengl/texturemanager.h
         ${PROJECT_SOURCE_DIR}/include/ghoul/opengl/textureunit.h
+        ${PROJECT_SOURCE_DIR}/include/ghoul/opengl/texturearray.h
         ${PROJECT_SOURCE_DIR}/include/ghoul/opengl/vertexbufferobject.h
         ${PROJECT_SOURCE_DIR}/include/ghoul/opengl/vertexbufferobject.inl
     )

--- a/src/opengl/texturearray.cpp
+++ b/src/opengl/texturearray.cpp
@@ -1,0 +1,131 @@
+/*****************************************************************************************
+*                                                                                       *
+* GHOUL                                                                                 *
+* General Helpful Open Utility Library                                                  *
+*                                                                                       *
+* Copyright (c) 2012-2017                                                               *
+*                                                                                       *
+* Permission is hereby granted, free of charge, to any person obtaining a copy of this  *
+* software and associated documentation files (the "Software"), to deal in the Software *
+* without restriction, including without limitation the rights to use, copy, modify,    *
+* merge, publish, distribute, sublicense, and/or sell copies of the Software, and to    *
+* permit persons to whom the Software is furnished to do so, subject to the following   *
+* conditions:                                                                           *
+*                                                                                       *
+* The above copyright notice and this permission notice shall be included in all copies *
+* or substantial portions of the Software.                                              *
+*                                                                                       *
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,   *
+* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A         *
+* PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT    *
+* HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF  *
+* CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE  *
+* OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                         *
+****************************************************************************************/
+
+#include <ghoul/opengl/texturearray.h>
+
+#include <ghoul/misc/assert.h>
+
+#include <ghoul/logging/logmanager.h>
+
+namespace {
+	const std::string _loggerCat = "TextureArray";
+}
+
+namespace ghoul {
+namespace opengl {
+
+TextureArray::TextureArray(glm::uvec3 dimensions, int size, GLint format, GLint internalFormat, GLenum dataType, bool allocateData)
+	: _dimensions(std::move(dimensions)),
+	_size(size),
+	_internalFormat(internalFormat),
+	_format(format),
+	_dataType(dataType),
+	_counter(0) {
+
+	ghoul_assert(_dimensions.x >= 1, "Element of dimensions must be bigger or equal 1");
+	ghoul_assert(_dimensions.y >= 1, "Element of dimensions must be bigger or equal 1");
+	ghoul_assert(_dimensions.z >= 1, "Element of dimensions must be bigger or equal 1");
+
+	initialize(allocateData);
+}
+
+/*TextureArray::~TextureArray() {
+	if (_id) {
+		glDeleteTextures(1, &_id);
+	}
+}*/
+
+void TextureArray::initialize(bool allocateData) {
+	determineTextureType();
+	generateId();
+	if (allocateData) {
+		allocateMemory();
+	}
+}
+
+void TextureArray::setType(GLenum type) {
+	ghoul_assert(
+		(type == GL_TEXTURE_2D_ARRAY),
+		"Type must be GL_TEXTURE_2D_ARRAY"
+	);
+	_type = type;
+}
+
+
+
+void TextureArray::determineTextureType() {
+	if (_dimensions.y == 1) {
+		_type = GL_TEXTURE_1D_ARRAY;
+	}
+	else {
+		_type = GL_TEXTURE_2D_ARRAY;
+	}
+}
+
+GLuint TextureArray::id() {
+	return _id;
+}
+
+void TextureArray::allocateMemory() {
+	bind();
+	glTexStorage3D(_type, 1, _internalFormat, _dimensions.x, _dimensions.y, _size);
+}
+
+void TextureArray::generateId() {
+	_id = 0;
+	glGenTextures(1, &_id);
+}
+
+void TextureArray::bind() const {
+	glBindTexture(_type, _id);
+}
+
+void TextureArray::uploadTexture(const void* pixels) {
+	bind();
+	switch (_type) {
+	case GL_TEXTURE_2D_ARRAY: {
+		glTexSubImage3D(
+			_type,
+			0,
+			0,
+			0,
+			_counter,
+			_dimensions.x,
+			_dimensions.y,
+			_dimensions.z,
+			_format,
+			_dataType,
+			pixels);
+
+		_counter++;
+		break;
+	}
+	default:
+		ghoul_assert(false, "Missing case label");
+	}
+}
+
+}
+}


### PR DESCRIPTION
A very basic wrapper, mainly for GL_TEXTURE_2D_ARRAY, but could be extended/improved to use GL_TEXTURE_1D_ARRAY.