### PR TITLE
Update Dictionary JSON/Lua formatters to support all types

### DIFF
--- a/src/misc/dictionaryjsonformatter.cpp
+++ b/src/misc/dictionaryjsonformatter.cpp
@@ -56,7 +56,7 @@ namespace {
         }
 
         std::stringstream values;
-        for (int i = 0; i < vec.size() - 1; i++) {
+        for (size_t i = 0; i < vec.size() - 1; i++) {
             double v = static_cast<double>(vec[i]);
             values << formatNumber(v) << ",";
         }

--- a/src/misc/dictionaryjsonformatter.cpp
+++ b/src/misc/dictionaryjsonformatter.cpp
@@ -29,11 +29,12 @@
 #include <ghoul/misc/dictionary.h>
 #include <numeric>
 #include <string>
+#include <sstream>
 
 namespace ghoul {
 
 namespace {
-    std::string formatDouble(double d) {
+    std::string formatNumber(double d) {
         // fmt::format will represent infinite values with 'inf' and NaNs with 'nan'.
         // These are not valid in JSON, so use 'null' instead
         if (!std::isfinite(d)) {
@@ -41,6 +42,27 @@ namespace {
         }
 
         return fmt::format("{}", d);
+    }
+
+    template <typename T>
+    std::string formatVector(const std::vector<T>& vec) {
+        static_assert(
+            std::is_same_v<T, double> || std::is_same_v<T, int>,
+            "Only double or ints allowed"
+        );
+
+        if (vec.empty()) {
+            return "[]";
+        }
+
+        std::stringstream values;
+        for (int i = 0; i < vec.size() - 1; i++) {
+            double v = static_cast<double>(vec[i]);
+            values << formatNumber(v) << ",";
+        }
+        values << vec.back();
+
+        return fmt::format("[{}]", values.str());
     }
 
     /**
@@ -58,40 +80,29 @@ namespace {
             return formatJson(subDictionary);
         }
 
-        if (dictionary.hasValue<glm::dvec4>(key)) {
-            glm::dvec4 vec = dictionary.value<glm::dvec4>(key);
-            return fmt::format(
-                "[{},{},{},{}]",
-                formatDouble(vec.x),
-                formatDouble(vec.y),
-                formatDouble(vec.z),
-                formatDouble(vec.w)
-            );
-        }
-
-        if (dictionary.hasValue<glm::dvec3>(key)) {
-            glm::dvec3 vec = dictionary.value<glm::dvec3>(key);
-            return fmt::format(
-                "[{},{},{}]",
-                formatDouble(vec.x),
-                formatDouble(vec.y),
-                formatDouble(vec.z)
-            );
-        }
-
-        if (dictionary.hasValue<glm::dvec2>(key)) {
-            glm::dvec2 vec = dictionary.value<glm::dvec2>(key);
-            return fmt::format("[{},{}]", formatDouble(vec.x), formatDouble(vec.y));
-        }
-
         if (dictionary.hasValue<double>(key)) {
             double value = dictionary.value<double>(key);
-            return formatDouble(value);
+            return formatNumber(value);
         }
 
         if (dictionary.hasValue<int>(key)) {
             int value = dictionary.value<int>(key);
-            return std::to_string(value);
+            return formatNumber(static_cast<double>(value));
+        }
+
+        if (dictionary.hasValue<bool>(key)) {
+            bool value = dictionary.value<bool>(key);
+            return value ? "true" : "false";
+        }
+
+        if (dictionary.hasValue<std::vector<int>>(key)) {
+            std::vector<int> vec = dictionary.value<std::vector<int>>(key);
+            return formatVector(vec);
+        }
+
+        if (dictionary.hasValue<std::vector<double>>(key)) {
+            std::vector<double> vec = dictionary.value<std::vector<double>>(key);
+            return formatVector(vec);
         }
 
         if (dictionary.hasValue<std::string>(key)) {

--- a/src/misc/dictionaryluaformatter.cpp
+++ b/src/misc/dictionaryluaformatter.cpp
@@ -78,6 +78,26 @@ namespace {
             (prettyPrint ? "\n" : "") + indent + "}";
     }
 
+    template <typename T>
+    std::string formatVector(const std::vector<T>& vec) {
+        static_assert(
+            std::is_same_v<T, double> || std::is_same_v<T, int>,
+            "Only double or ints allowed"
+        );
+
+        if (vec.empty()) {
+            return "{}";
+        }
+
+        std::string values;
+        for (int i = 0; i < vec.size() - 1; i++) {
+            values += fmt::format("{},", vec[i]);
+        }
+        values += fmt::format("{}", vec.back());
+
+        return fmt::format("{{{}}}", values);
+    }
+
     std::string formatValue(const Dictionary& dictionary, const std::string& key,
                             PrettyPrint prettyPrint, const std::string& indentation,
                             int indentationSteps)
@@ -85,21 +105,6 @@ namespace {
         if (dictionary.hasValue<Dictionary>(key)) {
             Dictionary subDictionary = dictionary.value<Dictionary>(key);
             return format(subDictionary, prettyPrint, indentation, indentationSteps);
-        }
-
-        if (dictionary.hasValue<glm::dvec4>(key)) {
-            glm::dvec4 vec = dictionary.value<glm::dvec4>(key);
-            return fmt::format("{{{},{},{},{}}}", vec.x, vec.y, vec.z, vec.w);
-        }
-
-        if (dictionary.hasValue<glm::dvec3>(key)) {
-            glm::dvec3 vec = dictionary.value<glm::dvec3>(key);
-            return fmt::format("{{{},{},{}}}", vec.x, vec.y, vec.z);
-        }
-
-        if (dictionary.hasValue<glm::dvec2>(key)) {
-            const glm::dvec2 vec = dictionary.value<glm::dvec2>(key);
-            return fmt::format("{{{},{}}}", vec.x, vec.y);
         }
 
         if (dictionary.hasValue<double>(key)) {
@@ -110,6 +115,21 @@ namespace {
         if (dictionary.hasValue<int>(key)) {
             int value = dictionary.value<int>(key);
             return std::to_string(value);
+        }
+
+        if (dictionary.hasValue<bool>(key)) {
+            bool value = dictionary.value<bool>(key);
+            return value ? "true" : "false";
+        }
+
+        if (dictionary.hasValue<std::vector<int>>(key)) {
+            std::vector<int> vec = dictionary.value<std::vector<int>>(key);
+            return formatVector(vec);
+        }
+
+        if (dictionary.hasValue<std::vector<double>>(key)) {
+            std::vector<double> vec = dictionary.value<std::vector<double>>(key);
+            return formatVector(vec);
         }
 
         if (dictionary.hasValue<std::string>(key)) {

--- a/src/misc/dictionaryluaformatter.cpp
+++ b/src/misc/dictionaryluaformatter.cpp
@@ -90,7 +90,7 @@ namespace {
         }
 
         std::string values;
-        for (int i = 0; i < vec.size() - 1; i++) {
+        for (size_t i = 0; i < vec.size() - 1; i++) {
             values += fmt::format("{},", vec[i]);
         }
         values += fmt::format("{}", vec.back());

--- a/tests/test_dictionaryjsonformatter.cpp
+++ b/tests/test_dictionaryjsonformatter.cpp
@@ -38,19 +38,79 @@ TEST_CASE("DictionaryJsonFormatter: Empty Dictionary", "[dictionaryjsonformatter
 TEST_CASE("DictionaryJsonFormatter: Simple Dictionary", "[dictionaryjsonformatter]") {
     using namespace std::string_literals;
     ghoul::Dictionary d;
+    d.setValue("boolFalse", false);
+    d.setValue("boolTrue", true);
     d.setValue("int", 1);
     d.setValue("double", 2.2);
-    d.setValue("vec2", glm::dvec2(0.f));
-    d.setValue("vec3", glm::dvec3(0.f));
-    d.setValue("vec4", glm::dvec4(0.f));
+    d.setValue("vec2", glm::dvec2(0.0));
+    d.setValue("vec3", glm::dvec3(0.0));
+    d.setValue("vec4", glm::dvec4(0.0));
     d.setValue("string", ""s);
 
     std::string res = ghoul::formatJson(d);
     REQUIRE(
         res ==
-        "{\"double\":2.2,\"int\":1,\"string\":\"\","
+        "{\"boolFalse\":false,\"boolTrue\":true,"
+        "\"double\":2.2,\"int\":1,\"string\":\"\","
         "\"vec2\":[0,0],\"vec3\":[0,0,0],"
         "\"vec4\":[0,0,0,0]}"
+    );
+}
+
+TEST_CASE("DictionaryJsonFormatter: Dictionary with Ivec", "[dictionaryjsonformatter]") {
+    using namespace std::string_literals;
+    ghoul::Dictionary d;
+    d.setValue("ivec2", glm::ivec2(0));
+    d.setValue("ivec3", glm::ivec3(0));
+    d.setValue("ivec4", glm::ivec4(0));
+
+    std::string res = ghoul::formatJson(d);
+    REQUIRE(
+        res ==
+        "{\"ivec2\":[0,0],\"ivec3\":[0,0,0],"
+        "\"ivec4\":[0,0,0,0]}"
+    );
+}
+
+TEST_CASE("DictionaryJsonFormatter: std::vectors", "[dictionaryjsonformatter]") {
+    using namespace std::string_literals;
+    ghoul::Dictionary d;
+    d.setValue("iVector", std::vector<int>{ 1, 2, 3, 4, 5 });
+    d.setValue("dVector", std::vector<double>{ 0.1, 0.2, 0.3, 0.4, 0.5 });
+    d.setValue("empty", std::vector<double>{});
+
+    std::string res = ghoul::formatJson(d);
+    REQUIRE(
+        res ==
+        "{\"dVector\":[0.1,0.2,0.3,0.4,0.5],"
+        "\"empty\":[],"
+        "\"iVector\":[1,2,3,4,5]}"
+    );
+}
+
+TEST_CASE("DictionaryJsonFormatter: Matrices", "[dictionaryjsonformatter]") {
+    using namespace std::string_literals;
+    ghoul::Dictionary d;
+    d.setValue("dmat2x2", glm::dmat2(0.0));
+    d.setValue("dmat2x3", glm::dmat2x3(0.0));
+    d.setValue("dmat2x4", glm::dmat2x4(0.0));
+
+    d.setValue("dmat3x3", glm::dmat3(0.0));
+    d.setValue("dmat3x2", glm::dmat3x2(0.0));
+    d.setValue("dmat3x4", glm::dmat3x4(0.0));
+
+    d.setValue("dmat4x4", glm::dmat4(0.0));
+    d.setValue("dmat4x2", glm::dmat4x2(0.0));
+    d.setValue("dmat4x3", glm::dmat4x3(0.0));
+
+    std::string res = ghoul::formatJson(d);
+    REQUIRE(
+        res ==
+        "{\"dmat2x2\":[0,0,0,0],\"dmat2x3\":[0,0,0,0,0,0],\"dmat2x4\":[0,0,0,0,0,0,0,0],"
+        "\"dmat3x2\":[0,0,0,0,0,0],\"dmat3x3\":[0,0,0,0,0,0,0,0,0],"
+        "\"dmat3x4\":[0,0,0,0,0,0,0,0,0,0,0,0],\"dmat4x2\":[0,0,0,0,0,0,0,0],"
+        "\"dmat4x3\":[0,0,0,0,0,0,0,0,0,0,0,0],"
+        "\"dmat4x4\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}"
     );
 }
 

--- a/tests/test_dictionaryluaformatter.cpp
+++ b/tests/test_dictionaryluaformatter.cpp
@@ -38,19 +38,79 @@ TEST_CASE("DictionaryLuaFormatter: Empty Dictionary", "[dictionaryluaformatter]"
 TEST_CASE("DictionaryLuaFormatter: Simple Dictionary", "[dictionaryluaformatter]") {
     using namespace std::string_literals;
     ghoul::Dictionary d;
+    d.setValue("boolFalse", false);
+    d.setValue("boolTrue", true);
     d.setValue("int", 1);
     d.setValue("double", 2.2);
-    d.setValue("vec2", glm::dvec2(0.f));
-    d.setValue("vec3", glm::dvec3(0.f));
-    d.setValue("vec4", glm::dvec4(0.f));
+    d.setValue("vec2", glm::dvec2(0.0));
+    d.setValue("vec3", glm::dvec3(0.0));
+    d.setValue("vec4", glm::dvec4(0.0));
     d.setValue("string", ""s);
 
     std::string res = ghoul::formatLua(d);
     REQUIRE(
         res ==
-        "{double=2.2,int=1,string=\"\","
+        "{boolFalse=false,boolTrue=true,"
+        "double=2.2,int=1,string=\"\","
         "vec2={0,0},vec3={0,0,0},"
         "vec4={0,0,0,0}}"
+    );
+}
+
+TEST_CASE("DictionaryLuaFormatter: Dictionary with Ivec", "[dictionaryluaformatter]") {
+    using namespace std::string_literals;
+    ghoul::Dictionary d;
+    d.setValue("ivec2", glm::ivec2(0));
+    d.setValue("ivec3", glm::ivec3(0));
+    d.setValue("ivec4", glm::ivec4(0));
+
+    std::string res = ghoul::formatLua(d);
+    REQUIRE(
+        res ==
+        "{ivec2={0,0},ivec3={0,0,0},"
+        "ivec4={0,0,0,0}}"
+    );
+}
+
+TEST_CASE("DictionaryLuaFormatter: std::vectors", "[dictionaryluaformatter]") {
+    using namespace std::string_literals;
+    ghoul::Dictionary d;
+    d.setValue("iVector", std::vector<int>{ 1, 2, 3, 4, 5 });
+    d.setValue("dVector", std::vector<double>{ 0.1, 0.2, 0.3, 0.4, 0.5 });
+    d.setValue("empty", std::vector<double>{});
+
+    std::string res = ghoul::formatLua(d);
+    REQUIRE(
+        res ==
+        "{dVector={0.1,0.2,0.3,0.4,0.5},"
+        "empty={},"
+        "iVector={1,2,3,4,5}}"
+    );
+}
+
+TEST_CASE("DictionaryLuaFormatter: Matrices", "[dictionaryluaformatter]") {
+    using namespace std::string_literals;
+    ghoul::Dictionary d;
+    d.setValue("dmat2x2", glm::dmat2(0.0));
+    d.setValue("dmat2x3", glm::dmat2x3(0.0));
+    d.setValue("dmat2x4", glm::dmat2x4(0.0));
+
+    d.setValue("dmat3x3", glm::dmat3(0.0));
+    d.setValue("dmat3x2", glm::dmat3x2(0.0));
+    d.setValue("dmat3x4", glm::dmat3x4(0.0));
+
+    d.setValue("dmat4x4", glm::dmat4(0.0));
+    d.setValue("dmat4x2", glm::dmat4x2(0.0));
+    d.setValue("dmat4x3", glm::dmat4x3(0.0));
+
+    std::string res = ghoul::formatLua(d);
+    REQUIRE(
+        res ==
+        "{dmat2x2={0,0,0,0},dmat2x3={0,0,0,0,0,0},dmat2x4={0,0,0,0,0,0,0,0},"
+        "dmat3x2={0,0,0,0,0,0},dmat3x3={0,0,0,0,0,0,0,0,0},"
+        "dmat3x4={0,0,0,0,0,0,0,0,0,0,0,0},dmat4x2={0,0,0,0,0,0,0,0},"
+        "dmat4x3={0,0,0,0,0,0,0,0,0,0,0,0},"
+        "dmat4x4={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}}"
     );
 }
 


### PR DESCRIPTION
Fixes #64 and also adds support for glm matrix and vector types and std::vectors in formatters