### PR TITLE
Distinguished value function names to prevent gcc compiler namespace …

### DIFF
--- a/include/ghoul/lua/lua_helper.h
+++ b/include/ghoul/lua/lua_helper.h
@@ -494,7 +494,6 @@ bool hasValue(lua_State* L, int location = 1);
 template <typename T>
 T value(lua_State* L, int location = 1, PopValue shouldPopValue = PopValue::Yes);
 
-
 /**
  * Extracts multiple values from the provided (and subsequent locations) of the provided
  * stack and return them as a tuple.  If at least one of the value does not exist or is of
@@ -562,6 +561,22 @@ T tryGetValue(lua_State* L, bool& success);
 
 namespace internal {
     void deinitializeGlobalState();
+
+    /**
+     * Handles the extraction of the value, considering the various possible types. The
+     * function value() handles the optional variable case, but calls this function to do
+     * the actual extraction.
+     *
+     * \tparam T The type of the return value. If the value at the provided location of the
+     *           stack is not T a LuaFormatException is thrown
+     * \param L The stack from which the value is extracted
+     * \param location The location from which the value should be extracted
+     *
+     * \throw LuaFormatException If the value at the provided stack location is not T
+     * \pre \L must not be nullptr
+     */
+    template <typename T>
+    T valueInner(lua_State* L, int location = 1);
 } // namespace internal
 
 } // namespace ghoul::lua

--- a/include/ghoul/lua/lua_helper.inl
+++ b/include/ghoul/lua/lua_helper.inl
@@ -143,7 +143,7 @@ constexpr Variant variantValue(lua_State* L, int location) {
     using T = std::variant_alternative_t<I, Variant>;
 
     if (hasValue<T>(L, location)) {
-        return value<T>(L, location);
+        return valueInner<T>(L, location);
     }
 
     if constexpr (I+1 != std::variant_size_v<Variant>) {
@@ -301,7 +301,7 @@ std::string Name() {
 }
 
 template <typename T>
-T value(lua_State* L, int location) {
+T valueInner(lua_State* L, int location) {
     if (!hasValue<T>(L, location)) {
         std::string name = Name<T>();
         // If we get this far, none of the previous return statements were hit
@@ -392,7 +392,7 @@ T value(lua_State* L, int location, PopValue shouldPopValue) {
             return std::nullopt;
         }
         else {
-            T res = internal::value<typename T::value_type>(L, location);
+            T res = internal::valueInner<typename T::value_type>(L, location);
             if (shouldPopValue) {
                 lua_remove(L, location);
             }
@@ -400,7 +400,7 @@ T value(lua_State* L, int location, PopValue shouldPopValue) {
         }
     }
     else {
-        T res = internal::value<T>(L, location);
+        T res = internal::valueInner<T>(L, location);
         if (shouldPopValue) {
             lua_remove(L, location);
         }


### PR DESCRIPTION
…confusion

The gcc compiler seems to be calling `value` instead of `internal::value` from function `variantValue`.