### PR TITLE
Add helper functions for converting string to upper or lower case

### DIFF
--- a/include/ghoul/misc/misc.h
+++ b/include/ghoul/misc/misc.h
@@ -32,14 +32,14 @@
 namespace ghoul {
 
 /**
- * Convert a string to contain only upper case letters
+ * Convert a string to contain only upper case letters.
  *
  * \param s The string to convert to only upper case letters
  */
 void toUpperCase(std::string& s);
 
 /**
- * Convert a string to contain only lower case letters
+ * Convert a string to contain only lower case letters.
  *
  * \param s The string to convert to only lower case letters
  */

--- a/include/ghoul/misc/misc.h
+++ b/include/ghoul/misc/misc.h
@@ -32,6 +32,20 @@
 namespace ghoul {
 
 /**
+ * Convert a string to contain only upper case letters
+ *
+ * \param s The string to convert to only upper case letters
+ */
+void toUpperCase(std::string& s);
+
+/**
+ * Convert a string to contain only lower case letters
+ *
+ * \param s The string to convert to only lower case letters
+ */
+void toLowerCase(std::string& s);
+
+/**
  * Separates the provided \p input URI into separate parts. If \p input is
  * `a.b.c.d 1.e`, the returned vector will contain one entry for
  * `a`, `b`, `c`, `d 1`, and `e`. If an error occurred, an exception will be thrown.

--- a/src/misc/misc.cpp
+++ b/src/misc/misc.cpp
@@ -30,6 +30,18 @@
 
 namespace ghoul {
 
+void toUpperCase(std::string& s) {
+    for (size_t i = 0; i < s.size(); i++) {
+        s[i] = static_cast<char>(toupper(s[i]));
+    }
+}
+
+void toLowerCase(std::string& s) {
+    for (size_t i = 0; i < s.size(); i++) {
+        s[i] = static_cast<char>(tolower(s[i]));
+    }
+}
+
 std::vector<std::string> tokenizeString(const std::string& input, char separator) {
     size_t separatorPos = input.find(separator);
     if (separatorPos == std::string::npos) {


### PR DESCRIPTION
Maybe a bit of a redundant or "too simple" function, but we do this a bit differently in several parts of the code and this is definitely a case where its more readable to have a helper function that explains what the simple for loop does. 

(Spent quite a while debugging a piece of code where the problem was that I had missed that a string was always converted to lower case...)