### PR TITLE
Allow comments and empty lines at the top of a csv file

### DIFF
--- a/src/misc/csvreader.cpp
+++ b/src/misc/csvreader.cpp
@@ -37,10 +37,9 @@ namespace {
         std::string line;
         while (std::getline(file, line)) {
             ghoul::trimWhitespace(line);
-            if (!line.empty() && line.starts_with("#")) {
+            if (!line.empty() && !line.starts_with("#")) {
                 break;
             }
-
         }
         return line;
     }

--- a/src/misc/csvreader.cpp
+++ b/src/misc/csvreader.cpp
@@ -33,15 +33,11 @@
 #include <fstream>
 
 namespace {
-    bool startsWith(std::string lhs, std::string_view rhs) noexcept {
-        return (rhs.size() <= lhs.size()) && (lhs.substr(0, rhs.size()) == rhs);
-    }
-
     std::string readFirstValidLine(std::ifstream& file) {
         std::string line;
         while (std::getline(file, line)) {
             ghoul::trimWhitespace(line);
-            if (!line.empty() && !startsWith(line, "#")) {
+            if (!line.empty() && line.starts_with("#")) {
                 break;
             }
 
@@ -63,7 +59,7 @@ namespace {
             ghoul::trimWhitespace(line);
 
             // Skip comments and empty lines
-            if (line.empty() || startsWith(line, "#")) {
+            if (line.empty() || line.starts_with("#")) {
                 continue;
             }
 


### PR DESCRIPTION
Allow `#` comments at the top of a CSV file, similarly to how the eoxplanet archive prepares their files (E.g. the ones downloaded from [this page](https://exoplanetarchive.ipac.caltech.edu/cgi-bin/TblView/nph-tblView?app=ExoTbls&config=PSCompPars))

The reader will now also skip empty lines