### PR TITLE
Add support for model vertex colors

### DIFF
--- a/include/ghoul/io/model/modelmesh.h
+++ b/include/ghoul/io/model/modelmesh.h
@@ -50,7 +50,7 @@ public:
         GLfloat tex[2];
         GLfloat normal[3];
         GLfloat tangent[3];
-        GLfloat color[3] = {0.f, 0.f, 0.f};
+        GLfloat color[3] = { 0.f, 0.f, 0.f };
     };
 
     struct Texture {
@@ -79,6 +79,7 @@ public:
 
     void setInvisible(bool isInvisible);
     bool isInvisible() const;
+    bool hasVertexColors() const;
     bool isTransparent() const;
 
     const std::vector<Vertex>& vertices() const;

--- a/include/ghoul/io/model/modelmesh.h
+++ b/include/ghoul/io/model/modelmesh.h
@@ -50,6 +50,7 @@ public:
         GLfloat tex[2];
         GLfloat normal[3];
         GLfloat tangent[3];
+        GLfloat color[3] = {0.f, 0.f, 0.f};
     };
 
     struct Texture {
@@ -64,7 +65,8 @@ public:
     static void generateDebugTexture(ModelMesh::Texture& texture);
 
     ModelMesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices,
-        std::vector<Texture> textures, bool isInvisible = false);
+        std::vector<Texture> textures, bool isInvisible = false,
+        bool hasVertexColors = false);
 
     ModelMesh(ModelMesh&&) noexcept = default;
     ~ModelMesh() noexcept = default;
@@ -89,6 +91,7 @@ private:
     std::vector<Texture> _textures;
 
     bool _isInvisible = false;
+    bool _hasVertexColors = false;
 
     GLuint _vaoID = 0;
     GLuint _vbo = 0;

--- a/src/io/model/modelmesh.cpp
+++ b/src/io/model/modelmesh.cpp
@@ -226,6 +226,10 @@ bool ModelMesh::isInvisible() const {
     return _isInvisible;
 }
 
+bool ModelMesh::hasVertexColors() const {
+    return _hasVertexColors;
+}
+
 bool ModelMesh::isTransparent() const {
     for (const Texture& t : _textures) {
         if ((t.type == TextureType::TextureDiffuse ||

--- a/src/io/model/modelmesh.cpp
+++ b/src/io/model/modelmesh.cpp
@@ -81,22 +81,19 @@ void ModelMesh::render(opengl::ProgramObject& program, const glm::mat4x4& meshTr
     int textureUnitIndex = 0;
 
     if (!isProjection) {
+        // Use embeded vertex colors if specified
+        program.setUniform("use_vertex_colors", _hasVertexColors);
+
         if (isFullyTexturedModel) {
             // Reset shader
             program.setUniform("has_texture_diffuse", false);
             program.setUniform("has_texture_normal", false);
             program.setUniform("has_texture_specular", false);
             program.setUniform("has_color_specular", false);
-            program.setUniform("use_vertex_colors", false);
 
             // If mesh is invisible and it has not been forced to render then don't render
             if (_isInvisible && _textures.empty()) {
                 return;
-            }
-
-            // Use embeded vertex colors if specified
-            if (_hasVertexColors) {
-                program.setUniform("use_vertex_colors", true);
             }
 
             // Bind appropriate textures
@@ -146,7 +143,6 @@ void ModelMesh::render(opengl::ProgramObject& program, const glm::mat4x4& meshTr
         else {
             // Reset shader
             program.setUniform("has_texture_diffuse", false);
-            program.setUniform("use_vertex_colors", false);
 
             // Bind appropriate textures
             for (const Texture& texture : _textures) {

--- a/src/io/model/modelreaderassimp.cpp
+++ b/src/io/model/modelreaderassimp.cpp
@@ -246,6 +246,7 @@ namespace {
         std::vector<ModelMesh::Vertex> vertexArray;
         std::vector<unsigned int> indexArray;
         std::vector<ModelMesh::Texture> textureArray;
+        bool hasVertexColors = false;
 
         // Vertices
         vertexArray.reserve(mesh.mNumVertices);
@@ -294,6 +295,19 @@ namespace {
                 vertex.tangent[2] = 0.f;
             }
 
+            // Color, only check the first color set
+            // @TODO: (malej 2024-07-08) Handle the other colors in the set up to
+            // AI_MAX_NUMBER_OF_COLOR_SETS.
+            //
+            // @TODO: (malej 2024-07-08) Handle alpha channel as well
+            if (mesh.HasVertexColors(0)) {
+                aiColor4D* color = &mesh.mColors[0][i];
+                vertex.color[0] = color->r;
+                vertex.color[1] = color->g;
+                vertex.color[2] = color->b;
+                hasVertexColors = true;
+            }
+
             vertexArray.push_back(std::move(vertex));
         }
 
@@ -312,8 +326,8 @@ namespace {
         // Process materials and textures
         aiMaterial* material = scene.mMaterials[mesh.mMaterialIndex];
 
-        // If there is not material then do not add the mesh
-        if (!material) {
+        // If there is not material or color then do not add the mesh
+        if (!material || !hasVertexColors) {
             return ModelMesh(
                 std::move(vertexArray),
                 std::move(indexArray),
@@ -497,7 +511,9 @@ namespace {
         return ModelMesh(
             std::move(vertexArray),
             std::move(indexArray),
-            std::move(textureArray)
+            std::move(textureArray),
+            false,
+            hasVertexColors
         );
     }
 

--- a/src/io/model/modelreaderassimp.cpp
+++ b/src/io/model/modelreaderassimp.cpp
@@ -326,8 +326,8 @@ namespace {
         // Process materials and textures
         aiMaterial* material = scene.mMaterials[mesh.mMaterialIndex];
 
-        // If there is not material or color then do not add the mesh
-        if (!material || !hasVertexColors) {
+        // If there is no material and no color then do not add the mesh
+        if (!material && !hasVertexColors) {
             return ModelMesh(
                 std::move(vertexArray),
                 std::move(indexArray),


### PR DESCRIPTION
This PR adds support to load models with vertex colors. The vertex color is applied as a multiplication factor to any color that already exists for that vertex from any other material/texture. This PR also updates the caching version for the models, previously cached models will automatically be deleted and replaced with new ones when this is run for the first time. 

Needs to be used together with PR https://github.com/OpenSpace/OpenSpace/pull/3346 in the OpenSpace repo (see that PR for testing instructions).

Two things to note:
1. Assimp allows each vertex to have up to 8 colors per vertex, for now, we only check and use the first specified color.
2. Assimp always assumes the color has 4 channels including alpha. This leads to models that only have RGB automatically having a 0 defined in the alpha channel (at least that is what I observed with the test models I used). This makes it very hard for us to know whether a 0 alpha is intentional or not. Therefore, we ignore the alpha value and only support RGB as vertex colors for now. 