### PR TITLE
Don't compile Catch2 if tests are disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(GHOUL_MODULE_FONTRENDERING "Enable Fontrendering" ON)
 option(GHOUL_MODULE_LUA "Enable Lua" ON)
 option(GHOUL_MODULE_OPENGL "Enable OpenGL" ON)
 option(GHOUL_MODULE_SYSTEMCAPABILITIES "Enable System Capabilities" ON)
+option(GHOUL_HAVE_TESTS "Activate the unit tests" ON)
 
 option(BUILD_SHARED_LIBS "Build package with shared libraries" OFF)
 
@@ -85,7 +86,6 @@ add_subdirectory(src)
 add_subdirectory(ext SYSTEM)
 
 # Other applications
-option(GHOUL_HAVE_TESTS "Activate the unit tests" ON)
 if (GHOUL_HAVE_TESTS)
   begin_header("Generating unit test")
   add_subdirectory(tests)

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -55,13 +55,15 @@ message(STATUS "Including GLM found at ${GLM_INCLUDE_DIRS}")
 target_include_directories(Ghoul SYSTEM PUBLIC ${GLM_INCLUDE_DIRS})
 end_dependency("GLM")
 
-add_subdirectory(catch2)
-# Catch2 by default compiles with C++14, which leads to some linker errors:
-# https://github.com/catchorg/Catch2/issues/2046
-target_compile_features(Catch2 PUBLIC cxx_std_20)
-target_compile_features(Catch2WithMain PUBLIC cxx_std_20)
-set_target_properties(Catch2 PROPERTIES FOLDER External)
-set_target_properties(Catch2WithMain PROPERTIES FOLDER External)
+if (GHOUL_HAVE_TESTS)
+  add_subdirectory(catch2)
+  # Catch2 by default compiles with C++14, which leads to some linker errors:
+  # https://github.com/catchorg/Catch2/issues/2046
+  target_compile_features(Catch2 PUBLIC cxx_std_20)
+  target_compile_features(Catch2WithMain PUBLIC cxx_std_20)
+  set_target_properties(Catch2 PROPERTIES FOLDER External)
+  set_target_properties(Catch2WithMain PROPERTIES FOLDER External)
+endif()
 
 if (GHOUL_MODULE_OPENGL)
   begin_module("OpenGL")


### PR DESCRIPTION
Should strip some build time when tests are not needed, e.g. for packaging purposes.

On my machine, it removes about 10% of the build time.