### PR TITLE
changes needed for MacOS build

### DIFF
--- a/src/filesystem/cachemanager.cpp
+++ b/src/filesystem/cachemanager.cpp
@@ -49,7 +49,7 @@ namespace {
         // something that cannot occur in the filesystem
         constexpr char HashDelimiter = '|';
 
-        const std::string s = std::format("{}{}{}", file, HashDelimiter, info);
+        const std::string s = std::format("{}{}{}", file.string(), HashDelimiter, info);
         const unsigned int hash = ghoul::hashCRC32(s);
         return hash;
     }
@@ -59,7 +59,7 @@ namespace {
             throw ghoul::RuntimeError(
                 std::format(
                     "Error retrieving last-modified date for '{}'. File did not exist",
-                    path
+                    path.string()
                 ),
                 "Cache"
             );
@@ -87,7 +87,7 @@ namespace {
             std::string msg(buffer.data());
             throw ghoul::RuntimeError(
                 std::format(
-                    "Could not retrieve last-modified date for '{}': {}", path, msg
+                    "Could not retrieve last-modified date for '{}': {}", path.string(), msg
                 ),
                 "Cache"
             );
@@ -109,7 +109,7 @@ namespace {
                 );
                 std::string msg(buffer.data());
                 throw ghoul::RuntimeError(
-                    std::format("'FileTimeToSystemTime' failed for '{}': {}", path, msg),
+                    std::format("'FileTimeToSystemTime' failed for '{}': {}", path.string(), msg),
                     "Cache"
                 );
             }
@@ -152,7 +152,7 @@ namespace {
                     std::format(
                         "File contained in cache directory '{}' contains a file "
                         "with name '{}' instead of expected '{}'",
-                        path, thisFilename, parent
+                        path.string(), thisFilename.string(), parent.string()
                     ),
                     "Cache"
                 );
@@ -209,7 +209,7 @@ CacheManager::~CacheManager() {
     const std::filesystem::path path = _directory / CacheFile;
     std::ofstream file(path, std::ofstream::out);
     if (!file.good()) {
-        LERROR(std::format("Could not open '{}' for writing cache version file", path));
+        LERROR(std::format("Could not open '{}' for writing cache version file", path.string()));
     }
 
     file << CacheVersion;
@@ -223,7 +223,7 @@ std::filesystem::path CacheManager::cachedFilename(const std::filesystem::path& 
     const size_t pos = n.find_first_of("/\\?%*:|\"<>");
     if (pos != std::string::npos) {
         throw ghoul::RuntimeError(
-            std::format("Argument '{}' contains an illegal character", baseName),
+            std::format("Argument '{}' contains an illegal character", baseName.string()),
             "Cache"
         );
     }
@@ -248,7 +248,7 @@ std::filesystem::path CacheManager::cachedFilename(const std::filesystem::path& 
         std::filesystem::create_directory(destinationBase);
     }
 
-    const std::string destination = std::format("{}/{}", destinationBase, hash);
+    const std::string destination = std::format("{}/{}", destinationBase.string(), hash);
 
     // The new destination should always not exist, since we checked before if we have the
     // value in the map and only get here if it isn't; persistent cache entries are always
@@ -265,7 +265,7 @@ std::filesystem::path CacheManager::cachedFilename(const std::filesystem::path& 
     }
 
     // Generate and output the newly generated cache name
-    const std::string cachedName = std::format("{}/{}", destination, baseName);
+    const std::string cachedName = std::format("{}/{}", destination, baseName.string());
 
     // Store the cache information in the map
     _files[hash] = cachedName;
@@ -280,7 +280,7 @@ bool CacheManager::hasCachedFile(const std::filesystem::path& file,
     const size_t pos = n.find_first_of("/\\?%*:|\"<>");
     if (pos != std::string::npos) {
         throw ghoul::RuntimeError(
-            std::format("Argument '{}' contains an illegal character", baseName),
+            std::format("Argument '{}' contains an illegal character", baseName.string()),
             "Cache"
         );
     }
@@ -305,7 +305,7 @@ void CacheManager::removeCacheFile(const std::filesystem::path& file,
     const size_t pos = n.find_first_of("/\\?%*:|\"<>");
     if (pos != std::string::npos) {
         throw ghoul::RuntimeError(
-            std::format("Argument '{}' contains an illegal character", baseName),
+            std::format("Argument '{}' contains an illegal character", baseName.string()),
             "Cache"
         );
     }

--- a/src/filesystem/filesystem.cpp
+++ b/src/filesystem/filesystem.cpp
@@ -74,7 +74,7 @@ FileSystem* FileSystem::_instance = nullptr;
 
 FileSystem::FileSystem() {
     std::filesystem::path temporaryPath = std::filesystem::temp_directory_path();
-    LINFO(std::format("Set temporary path ${{TEMPORARY}} to '{}'", temporaryPath));
+    LINFO(std::format("Set temporary path ${{TEMPORARY}} to '{}'", temporaryPath.string()));
     registerPathToken("${TEMPORARY}", temporaryPath);
 
 #if !defined(WIN32) && !defined(__APPLE__)
@@ -259,7 +259,7 @@ std::filesystem::path FileSystem::resolveShellLink(std::filesystem::path path) {
     if (FAILED(hres)) {
         throw ghoul::RuntimeError(std::format(
             "Failed initializing ShellLink when resolving path '{}' with error: {}",
-            path, hres
+            path.string(), hres
         ));
     }
     defer { psl->Release(); };
@@ -269,7 +269,7 @@ std::filesystem::path FileSystem::resolveShellLink(std::filesystem::path path) {
     if (FAILED(hres)) {
         throw ghoul::RuntimeError(std::format(
             "Failed querying interface when resolving path '{}' with error: {}",
-            path, hres
+            path.string(), hres
         ));
     }
     defer{ ppf->Release(); };
@@ -280,21 +280,21 @@ std::filesystem::path FileSystem::resolveShellLink(std::filesystem::path path) {
     if (res == 0) {
         DWORD error = GetLastError();
         throw ghoul::RuntimeError(std::format(
-            "Failed converting path '{}' with error: {}", path, error
+            "Failed converting path '{}' with error: {}", path.string(), error
         ));
     }
 
     hres = ppf->Load(wsz, STGM_READ);
     if (FAILED(hres)) {
         throw ghoul::RuntimeError(std::format(
-            "Failed loading ShellLink file at path '{}' with error: {}", path, hres
+            "Failed loading ShellLink file at path '{}' with error: {}", path.string(), hres
         ));
     }
 
     hres = psl->Resolve(nullptr, 0);
     if (FAILED(hres)) {
         throw ghoul::RuntimeError(std::format(
-            "Failed to resolve ShellLink at path '{}' with error: {}", path, hres
+            "Failed to resolve ShellLink at path '{}' with error: {}", path.string(), hres
         ));
     }
 
@@ -303,7 +303,7 @@ std::filesystem::path FileSystem::resolveShellLink(std::filesystem::path path) {
     hres = psl->GetPath(szGotPath, MAX_PATH, &wfd, SLGP_SHORTPATH);
     if (FAILED(hres)) {
         throw ghoul::RuntimeError(std::format(
-            "Failed to get path of ShellLink at path '{}' with error: {}", path, hres
+            "Failed to get path of ShellLink at path '{}' with error: {}", path.string(), hres
         ));
     }
 

--- a/src/font/fontmanager.cpp
+++ b/src/font/fontmanager.cpp
@@ -74,7 +74,7 @@ unsigned int FontManager::registerFontPath(std::string_view fontName,
             throw RuntimeError(
                 std::format(
                     "Font '{}' was registered with path '{}' before, trying '{}' now",
-                    fontName, registeredPath, filePath
+                    fontName, registeredPath.string(), filePath.string()
                 ),
                 "FontManager"
             );

--- a/src/font/fontrenderer.cpp
+++ b/src/font/fontrenderer.cpp
@@ -309,20 +309,20 @@ FontRenderer::~FontRenderer() {
 std::unique_ptr<FontRenderer> FontRenderer::createDefault() {
     std::filesystem::path vsPath = absPath(DefaultVertexShaderPath);
     if (std::filesystem::is_regular_file(vsPath)) {
-        LDEBUG(std::format("Skipping creation of existing vertex shader '{}'", vsPath));
+        LDEBUG(std::format("Skipping creation of existing vertex shader '{}'", vsPath.string()));
     }
     else {
-        LDEBUG(std::format("Writing default vertex shader to '{}'", vsPath));
+        LDEBUG(std::format("Writing default vertex shader to '{}'", vsPath.string()));
         std::ofstream file(vsPath);
         file << DefaultVertexShaderSource;
     }
 
     std::filesystem::path fsPath = absPath(DefaultFragmentShaderPath);
     if (std::filesystem::is_regular_file(fsPath)) {
-        LDEBUG(std::format("Skipping creation of existing fragment shader '{}'", fsPath));
+        LDEBUG(std::format("Skipping creation of existing fragment shader '{}'", fsPath.string()));
     }
     else {
-        LDEBUG(std::format("Writing default fragment shader to '{}'", fsPath));
+        LDEBUG(std::format("Writing default fragment shader to '{}'", fsPath.string()));
         std::ofstream file(fsPath);
         file << DefaultFragmentShaderSource;
     }
@@ -349,20 +349,20 @@ std::unique_ptr<FontRenderer> FontRenderer::createDefault() {
 std::unique_ptr<FontRenderer> FontRenderer::createProjectionSubjectText() {
     std::filesystem::path vsPath = absPath(ProjectionVertexShaderPath);
     if (std::filesystem::is_regular_file(vsPath)) {
-        LDEBUG(std::format("Skipping creation of existing vertex shader '{}'", vsPath));
+        LDEBUG(std::format("Skipping creation of existing vertex shader '{}'", vsPath.string()));
     }
     else {
-        LDEBUG(std::format("Writing default vertex shader to '{}'", vsPath));
+        LDEBUG(std::format("Writing default vertex shader to '{}'", vsPath.string()));
         std::ofstream file(vsPath);
         file << ProjectionVertexShaderSource;
     }
 
     std::filesystem::path fsPath = absPath(ProjectionFragmentShaderPath);
     if (std::filesystem::is_regular_file(fsPath)) {
-        LDEBUG(std::format("Skipping creation of existing fragment shader '{}'", vsPath));
+        LDEBUG(std::format("Skipping creation of existing fragment shader '{}'", vsPath.string()));
     }
     else {
-        LDEBUG(std::format("Writing default fragment shader to '{}'", fsPath));
+        LDEBUG(std::format("Writing default fragment shader to '{}'", fsPath.string()));
         std::ofstream file(fsPath);
         file << ProjectionFragmentShaderSource;
     }

--- a/src/io/model/modelgeometry.cpp
+++ b/src/io/model/modelgeometry.cpp
@@ -165,7 +165,7 @@ namespace ghoul::modelgeometry {
 
 ModelGeometry::ModelCacheException::ModelCacheException(std::filesystem::path file,
                                                         std::string msg)
-    : RuntimeError(std::format("Error '{}' with cache file '{}'", msg, file))
+    : RuntimeError(std::format("Error '{}' with cache file '{}'", msg, file.string()))
     , filename(std::move(file))
     , errorMessage(std::move(msg))
 {}
@@ -907,7 +907,7 @@ bool ModelGeometry::saveToCacheFile(const std::filesystem::path& cachedFile) con
         // Name
         if (_animation->name().size() >= std::numeric_limits<uint8_t>::max()) {
             LWARNING(std::format(
-                "A maximum animaion name length of {} is supported",
+                "A maximum animation name length of {} is supported",
                 std::numeric_limits<uint8_t>::max()
             ));
         }

--- a/src/io/model/modelreader.cpp
+++ b/src/io/model/modelreader.cpp
@@ -47,7 +47,7 @@ namespace ghoul::io {
 ModelReader::MissingReaderException::MissingReaderException(std::string extension,
                                                             std::filesystem::path file_)
     : RuntimeError(std::format(
-        "No reader was found for extension '{}' with file '{}'", extension, file_
+        "No reader was found for extension '{}' with file '{}'", extension, file_.string()
     ))
     , fileExtension(std::move(extension))
     , file(std::move(file_))
@@ -81,15 +81,15 @@ std::unique_ptr<modelgeometry::ModelGeometry> ModelReader::loadModel(
     }
 
     if (!reader->needsCache()) {
-        LINFO(std::format("Loading ModelGeometry file '{}'", filename));
-        return reader->loadModel(filename, forceRenderInvisible, notifyInvisibleDropped);
+        LINFO(std::format("Loading ModelGeometry file '{}'", filename.string()));
+        return reader->loadModel(filename.string(), forceRenderInvisible, notifyInvisibleDropped);
     }
 
     std::filesystem::path cachedFile = FileSys.cacheManager()->cachedFilename(filename);
     const bool hasCachedFile = std::filesystem::is_regular_file(cachedFile);
     if (hasCachedFile) {
         LINFO(std::format(
-            "Cached file '{}' used for ModelGeometry file '{}'", cachedFile, filename
+            "Cached file '{}' used for ModelGeometry file '{}'", cachedFile.string(), filename.string()
         ));
 
         try {
@@ -104,7 +104,7 @@ std::unique_ptr<modelgeometry::ModelGeometry> ModelReader::loadModel(
         catch (const modelgeometry::ModelGeometry::ModelCacheException& e) {
             LINFO(std::format(
                 "Encountered problem '{}' while loading model from cache file '{}'. "
-                "Deleting cache", e.errorMessage, cachedFile
+                "Deleting cache", e.errorMessage, cachedFile.string()
             ));
             FileSys.cacheManager()->removeCacheFile(filename);
             // Intentional fall-through to the 'else' computation to generate the cache
@@ -113,10 +113,10 @@ std::unique_ptr<modelgeometry::ModelGeometry> ModelReader::loadModel(
 
     }
     else {
-        LINFO(std::format("Cache for ModelGeometry file '{}' not found", filename));
+        LINFO(std::format("Cache for ModelGeometry file '{}' not found", filename.string()));
     }
 
-    LINFO(std::format("Loading ModelGeometry file '{}'", filename));
+    LINFO(std::format("Loading ModelGeometry file '{}'", filename.string()));
 
     std::unique_ptr<modelgeometry::ModelGeometry> model =
         reader->loadModel(filename, forceRenderInvisible, notifyInvisibleDropped);
@@ -128,7 +128,7 @@ std::unique_ptr<modelgeometry::ModelGeometry> ModelReader::loadModel(
     catch (const modelgeometry::ModelGeometry::ModelCacheException& e) {
         LINFO(std::format(
             "Encountered problem '{}' while saving model to cache file '{}'. "
-            "Deleting cache", e.errorMessage, e.filename
+            "Deleting cache", e.errorMessage, e.filename.string()
         ));
 
         FileSys.cacheManager()->removeCacheFile(filename);

--- a/src/io/model/modelreaderassimp.cpp
+++ b/src/io/model/modelreaderassimp.cpp
@@ -148,7 +148,7 @@ namespace {
                     catch (const TextureReaderBase::TextureLoadException& e) {
                         LWARNING(std::format(
                             "Failed to load texture from '{}' with error '{}': "
-                            "Replacing with flashy color", e.filename, e.message
+                            "Replacing with flashy color", e.filename.string(), e.message
                         ));
                         ModelMesh::generateDebugTexture(meshTexture);
                         textureArray.push_back(std::move(meshTexture));
@@ -183,7 +183,7 @@ namespace {
                 catch (const TextureReader::MissingReaderException& e) {
                     LWARNING(std::format(
                         "Could not load unsupported texture from '{}' with extension "
-                        "'{}': Replacing with flashy color", e.file, e.fileExtension
+                        "'{}': Replacing with flashy color", e.file.string(), e.fileExtension
                     ));
                     ModelMesh::generateDebugTexture(meshTexture);
                     textureArray.push_back(std::move(meshTexture));
@@ -192,7 +192,7 @@ namespace {
                 catch (const TextureReaderBase::TextureLoadException& e) {
                     LWARNING(std::format(
                         "Failed to load texture from '{}' with error '{}': Replacing "
-                        "with flashy color", e.filename, e.message
+                        "with flashy color", e.filename.string(), e.message
                     ));
                     ModelMesh::generateDebugTexture(meshTexture);
                     textureArray.push_back(std::move(meshTexture));

--- a/src/io/model/modelreaderbase.cpp
+++ b/src/io/model/modelreaderbase.cpp
@@ -33,7 +33,7 @@ ModelReaderBase::ModelLoadException::ModelLoadException(std::filesystem::path na
                                                         std::string msg,
                                                         const ModelReaderBase* r)
     : RuntimeError(std::format(
-        "Error '{}' while loading model from file '{}'", msg, name), "ModelLoader"
+        "Error '{}' while loading model from file '{}'", msg, name.string()), "ModelLoader"
     )
     , filename(std::move(name))
     , errorMessage(std::move(msg))

--- a/src/io/texture/texturereader.cpp
+++ b/src/io/texture/texturereader.cpp
@@ -40,7 +40,7 @@ TextureReader::MissingReaderException::MissingReaderException(std::string extens
                                                               std::filesystem::path file_)
     : RuntimeError(
         std::format(
-            "No reader found for extension '{}' with file '{}'", extension, file_
+            "No reader found for extension '{}' with file '{}'", extension, file_.string()
         ),
         "IO"
     )

--- a/src/io/texture/texturereaderbase.cpp
+++ b/src/io/texture/texturereaderbase.cpp
@@ -32,7 +32,7 @@ namespace ghoul::io {
 TextureReaderBase::TextureLoadException::TextureLoadException(std::filesystem::path name,
                                                               std::string msg,
                                                               const TextureReaderBase* r)
-    : RuntimeError(std::format("Error loading texture '{}'", name), "TextureLoader")
+    : RuntimeError(std::format("Error loading texture '{}'", name.string()), "TextureLoader")
     , filename(std::move(name))
     , errorMessage(std::move(msg))
     , reader(r)

--- a/src/io/texture/texturereadercmap.cpp
+++ b/src/io/texture/texturereadercmap.cpp
@@ -44,7 +44,7 @@ std::unique_ptr<opengl::Texture> TextureReaderCMAP::loadTexture(
     if (nDimensions != 1) {
         throw ghoul::RuntimeError(std::format(
             "The number of dimensions for '{}' must be 1, but was {}",
-            filename, nDimensions
+            filename.string(), nDimensions
         ));
     }
 

--- a/src/logging/textlog.cpp
+++ b/src/logging/textlog.cpp
@@ -54,13 +54,13 @@ TextLog::TextLog(const std::filesystem::path& filename, int nLogRotation,
         const std::filesystem::path ext = filename.extension();
 
         std::filesystem::path newCandidate = filename;
-        newCandidate.replace_filename(std::format("{}-{}{}", fname, nLogRotation, ext));
+        newCandidate.replace_filename(std::format("{}-{}{}", fname.string(), nLogRotation, ext));
 
         std::filesystem::path oldCandidate = filename;
         if (nLogRotation > 1) {
             // We don't actually have a -0 version, it is just the base name
             oldCandidate.replace_filename(
-                std::format("{}-{}{}", fname, nLogRotation - 1, ext)
+                std::format("{}-{}{}", fname.string(), nLogRotation - 1, ext)
             );
         }
 

--- a/src/lua/lua_helper.cpp
+++ b/src/lua/lua_helper.cpp
@@ -138,14 +138,14 @@ LuaFormatException::LuaFormatException(std::string msg, std::filesystem::path fi
 {}
 
 LuaLoadingException::LuaLoadingException(std::string error, std::filesystem::path file)
-    : LuaRuntimeException(std::format("Error loading script '{}': {}", file, error))
+    : LuaRuntimeException(std::format("Error loading script '{}': {}", file.string(), error))
     , errorMessage(std::move(error))
     , filename(std::move(file))
 {}
 
 LuaExecutionException::LuaExecutionException(std::string error,
                                              std::filesystem::path file)
-    : LuaRuntimeException(std::format("Error executing script '{}': {}", file, error))
+    : LuaRuntimeException(std::format("Error executing script '{}': {}", file.string(), error))
     , errorMessage(std::move(error))
     , filename(std::move(file))
 {}

--- a/src/misc/csvreader.cpp
+++ b/src/misc/csvreader.cpp
@@ -176,7 +176,7 @@ std::vector<std::vector<std::string>> loadCSVFile(const std::filesystem::path& f
     const std::vector<std::string> elements = ghoul::tokenizeString(line, ',');
     if (elements.empty()) {
         throw ghoul::RuntimeError(
-            std::format("CSV file '{}' did not contain any lines", fileName)
+            std::format("CSV file '{}' did not contain any lines", fileName.string())
         );
     }
 
@@ -190,7 +190,7 @@ std::vector<std::vector<std::string>> loadCSVFile(const std::filesystem::path& f
             const auto it = std::find(elements.cbegin(), elements.cend(), column);
             if (it == elements.cend()) {
                 throw ghoul::RuntimeError(std::format(
-                    "CSV file '{}' did not contain the requested key {}", fileName, column
+                    "CSV file '{}' did not contain the requested key {}", fileName.string(), column
                 ));
             }
 

--- a/src/misc/exception.cpp
+++ b/src/misc/exception.cpp
@@ -39,7 +39,7 @@ RuntimeError::RuntimeError(std::string msg, std::string comp)
 }
 
 FileNotFoundError::FileNotFoundError(std::filesystem::path f, std::string comp)
-    : RuntimeError(std::format("Could not find file '{}'", f), std::move(comp))
+    : RuntimeError(std::format("Could not find file '{}'", f.string()), std::move(comp))
     , file(std::move(f))
 {}
 

--- a/src/opengl/shaderpreprocessor.cpp
+++ b/src/opengl/shaderpreprocessor.cpp
@@ -172,7 +172,7 @@ ShaderPreprocessor::ShaderPreprocessor(std::string shaderPath, Dictionary dictio
 
 ShaderPreprocessor::IncludeError::IncludeError(std::filesystem::path f)
     : ShaderPreprocessorError(
-        std::format("Could not resolve file path for include file '{}'", f)
+        std::format("Could not resolve file path for include file '{}'", f.string())
     )
     , file(std::move(f))
 {}
@@ -287,7 +287,7 @@ void ShaderPreprocessor::includeFile(const std::filesystem::path& path,
 
     std::ifstream stream = std::ifstream(path, std::ifstream::binary);
     if (!stream.good()) {
-        throw ghoul::RuntimeError(std::format("Error loading include file '{}'", path));
+        throw ghoul::RuntimeError(std::format("Error loading include file '{}'", path.string()));
     }
     ghoul_assert(stream.good() , "Input stream is not good");
 
@@ -305,7 +305,7 @@ void ShaderPreprocessor::includeFile(const std::filesystem::path& path,
         if (!environment.success) {
             throw ParserError(std::format(
                 "Could not parse line. '{}': {}",
-                path, environment.inputs.back().lineNumber
+                path.string(), environment.inputs.back().lineNumber
             ));
         }
     }
@@ -321,7 +321,7 @@ void ShaderPreprocessor::includeFile(const std::filesystem::path& path,
 
             throw ParserError(std::format(
                 "Unexpected end of file. Still processing #for loop from '{}': {}. {}",
-                p, lineNumber, debugString(environment)
+                p.string(), lineNumber, debugString(environment)
             ));
         }
     }
@@ -352,7 +352,7 @@ void ShaderPreprocessor::addLineNumber(ShaderPreprocessor::Env& env) {
 
     env.output << std::format(
         "{}\n#line {} {} // {}\n",
-        includeSeparator, env.inputs.back().lineNumber, fileIdentifier, filename
+        includeSeparator, env.inputs.back().lineNumber, fileIdentifier, filename.string()
     );
 }
 
@@ -400,7 +400,7 @@ bool ShaderPreprocessor::parseLine(ShaderPreprocessor::Env& env) {
 std::string ShaderPreprocessor::debugString(const ShaderPreprocessor::Env& env) {
     if (!env.inputs.empty()) {
         const ShaderPreprocessor::Input& input = env.inputs.back();
-        return std::format("{}: {}", input.file.path(), input.lineNumber);
+        return std::format("{}: {}", input.file.path().string(), input.lineNumber);
     }
     else {
         return "";
@@ -836,7 +836,7 @@ bool ShaderPreprocessor::parseEndFor(ShaderPreprocessor::Env& env) {
 
         throw ParserError(std::format(
             "Unexpected #endfor. Last #for was in {}: {}. {}",
-            path, lineNumber, debugString(env)
+            path.string(), lineNumber, debugString(env)
         ));
     }
 


### PR DESCRIPTION
Unfortunately, these changes are not enough to cleanly build Ghoul on MacOS 14 etc. `tests/test_luaconversions.cpp` calls `to_string` with vector arguments which are not available as formattable in namespace std. Copilot suggests creating a std::formatter template, I see that @alexanderbock has also suggested this in comments in the to_string function.