### PR TITLE
take care of MIME types on Linux clipboard

### DIFF
--- a/src/misc/clipboard.cpp
+++ b/src/misc/clipboard.cpp
@@ -97,9 +97,31 @@ std::string clipboardText() {
     return "";
 #else
     std::string text;
-    if (exec("xclip -o -sel c -f", text)) {
-        return text.substr(0, text.length());  // remove a line ending
+    // Try UTF8_STRING first
+    if (exec("xclip -o -selection clipboard -target UTF8_STRING", text)) {
+        if (!text.empty() && text.back() == '\n') {
+            text.pop_back();
+        }
+        return text;
     }
+
+    // Fallback: try text/plain;charset=utf-8
+    if (exec("xclip -o -selection clipboard -target text/plain;charset=utf-8", text)) {
+        if (!text.empty() && text.back() == '\n') {
+            text.pop_back();
+        }
+        return text;
+    }
+
+    // Final fallback: default text/plain
+    if (exec("xclip -o -selection clipboard -target text/plain", text)) {
+        if (!text.empty() && text.back() == '\n') {
+            text.pop_back();
+        }
+        return text;
+    }
+
+    // If all else fails
     return "";
 #endif
 }


### PR DESCRIPTION
fix crash on Linux due to the first MIME type being returned by xclip