### PR TITLE
Fixed missing commas in UniformCache39 and UniformCache40

### DIFF
--- a/include/ghoul/opengl/uniformcache.h
+++ b/include/ghoul/opengl/uniformcache.h
@@ -516,7 +516,7 @@ struct UniformCacheBase {};
         const std::array<const char*, 39> UniformNames = {                               \
             #v1, #v2, #v3, #v4, #v5, #v6, #v7, #v8, #v9, #v10, #v11, #v12, #v13, #v14,   \
             #v15, #v16, #v17, #v18, #v19, #v20, #v21, #v22, #v23, #v24, #v25, #v26,      \
-            #v27, #v28, #v29, #v30, #v31, #v32, #v33, #v34, #v35, #v36, #v37, #v38       \
+            #v27, #v28, #v29, #v30, #v31, #v32, #v33, #v34, #v35, #v36, #v37, #v38,      \
             #v39                                                                         \
         };                                                                               \
     }
@@ -533,7 +533,7 @@ struct UniformCacheBase {};
         const std::array<const char*, 40> UniformNames = {                               \
             #v1, #v2, #v3, #v4, #v5, #v6, #v7, #v8, #v9, #v10, #v11, #v12, #v13, #v14,   \
             #v15, #v16, #v17, #v18, #v19, #v20, #v21, #v22, #v23, #v24, #v25, #v26,      \
-            #v27, #v28, #v29, #v30, #v31, #v32, #v33, #v34, #v35, #v36, #v37, #v38       \
+            #v27, #v28, #v29, #v30, #v31, #v32, #v33, #v34, #v35, #v36, #v37, #v38,      \
             #v39, #v40                                                                   \
         };                                                                               \
     }


### PR DESCRIPTION
Two missing commas in the `#define`s for `UniformCache39` and `UniformCache40`. Was causing runtime warnings in the log.
