### PR TITLE
Texture and Reader updates 

### DIFF
--- a/include/ghoul/io/texture/texturereader.h
+++ b/include/ghoul/io/texture/texturereader.h
@@ -70,6 +70,27 @@ struct InvalidLoadException final : public RuntimeError {
 };
 
 /**
+ * Holds the information about a loaded image including its dimensions, channel count,
+ * and raw pixel data.
+ */
+struct ImageInfo {
+    /// The width and height of the image in pixels
+    glm::ivec2 dimensions;
+
+    /// The number of color channels (e.g., 3 for RGB, 4 for RGBA)
+    int nChannels;
+
+    /// The raw pixel data of the image
+    std::vector<std::byte> data;
+};
+
+/// TODO: Docs
+ImageInfo loadImage(const std::filesystem::path& filename);
+
+/// TODO: Docs
+ImageInfo loadImage(void* memory, size_t size, const std::string& format);
+
+/**
  * Loads the provided \p filename using the STB image library into a Texture and returns
  * it. The image format is determined by the extension of the \p filename.
  *

--- a/include/ghoul/io/texture/texturereader.h
+++ b/include/ghoul/io/texture/texturereader.h
@@ -174,7 +174,8 @@ std::unique_ptr<opengl::Texture> loadTexture(void* memory, size_t size,
     const std::string& format = "");
 
 /**
- * Returns the size of the image pointed to by \p filename.
+ * Loads the information about the image at the provided \p filename using the STB image
+ * library, without thefully loading the image data.
  *
  * \param filename The image file that should be inspected
  * \return The size of the image in pixels
@@ -183,7 +184,7 @@ std::unique_ptr<opengl::Texture> loadTexture(void* memory, size_t size,
  * \pre \p filename must not be empty
  * \pre The extension of \p filename must be among the supported file extensions
  */
-glm::ivec2 imageSize(const std::filesystem::path& filename);
+ImageInfo imageInfo(const std::filesystem::path& filename);
 
 /**
  * Returns Whether the provided file \p extension is supported by this reader, i.e., which

--- a/include/ghoul/io/texture/texturereader.h
+++ b/include/ghoul/io/texture/texturereader.h
@@ -84,10 +84,43 @@ struct ImageInfo {
     std::vector<std::byte> data;
 };
 
-/// TODO: Docs
+/**
+ * Loads the provided \p filename using the STB image library and returns the image
+ * information including dimensions, channel count, and raw pixel data. The image format
+ * is determined by the extension of the \p filename.
+ *
+ * \param filename The name of the file which should be loaded
+ * \return An ImageInfo structure containing the image dimensions, number of channels,
+ *         and raw pixel data
+ *
+ * \throw TextureLoadException If there was an error reading the \p filename
+ * \throw MissingReaderException If the extension in the \p filename is not supported
+ * \pre \p filename must not be empty
+ * \pre \p filename must have an extension
+ * \pre The extension of \p filename must be among the supported file extensions
+ */
 ImageInfo loadImage(const std::filesystem::path& filename);
 
-/// TODO: Docs
+/**
+ * Loads an image from the memory pointed at by \p memory using the STB image library and
+ * returns the image information including dimensions, channel count, and raw pixel data.
+ * The memory block must contain at least \p size number of bytes.
+ *
+ * \param memory The memory that contains the bytes of the image to be loaded
+ * \param size The number of bytes contained in \p memory
+ * \param format The format of the image pointed to by \p memory. This parameter should
+ *        be the same as the usual file extension for the image and is used to determine
+ *        if the file type is supported for reading
+ * \return An ImageInfo structure containing the image dimensions, number of channels,
+ *         and raw pixel data
+ *
+ * \throw TextureLoadException If there was an error reading the \p memory
+ * \throw MissingReaderException If the \p format is not supported
+ * \throw InvalidLoadException If the load result is invalid
+ * \pre \p memory must not be `nullptr`
+ * \pre \p size must be > 0
+ * \pre \p format must be among the supported file extensions
+ */
 ImageInfo loadImage(void* memory, size_t size, const std::string& format);
 
 /**
@@ -132,6 +165,7 @@ std::unique_ptr<opengl::Texture> loadTexture(const std::filesystem::path& filena
  * \throw MissingReaderException If the extension in the \p filename is not supported
  * \pre \p memory must not be `nullptr`
  * \pre \p size must be > 0
+ * \pre \p format must be among the supported file extensions
  * \pre \p nDimensions The number of texture dimension must be 1, 2, or 3
  * \pre The extension of \p filename must be among the supported file extensions
  */

--- a/include/ghoul/io/texture/texturereader.h
+++ b/include/ghoul/io/texture/texturereader.h
@@ -175,7 +175,7 @@ std::unique_ptr<opengl::Texture> loadTexture(void* memory, size_t size,
 
 /**
  * Loads the information about the image at the provided \p filename using the STB image
- * library, without thefully loading the image data.
+ * library, without fully loading the image data.
  *
  * \param filename The image file that should be inspected
  * \return The size of the image in pixels

--- a/include/ghoul/opengl/texture.h
+++ b/include/ghoul/opengl/texture.h
@@ -280,6 +280,15 @@ public:
     std::vector<std::byte> pixelData() const;
 
     /**
+     * Returns the recommended `Format` corresponding to the given number of color
+     * channels.
+     *
+     * \param nChannels The number of channels to return a format for
+     * \return The recommended `Format`
+     */
+    static Format formatFromNumChannels(int nChannels);
+
+    /**
      * Downloads the contents of this texture into CPU memory and stores it locally. The
      * The data can then be retrieved through a call to `cachedPixelData` which will use
      * this cached data. The cache can be cleared and the memory reclaimed through a call

--- a/include/ghoul/opengl/texture.h
+++ b/include/ghoul/opengl/texture.h
@@ -153,13 +153,15 @@ public:
         /// Sets the border color of the texture
         std::optional<glm::vec4> borderColor = std::nullopt;
 
-        /// Changes the general swizzle mask of the texture
+        /// Changes the general swizzle mask of the texture. Note that single-channel
+        /// grayscale images, i.e., with only a Red channel, will be automatically
+        /// swizzled to RGB if `autoSwizzleGrayscale`  is true (this is the default)
         std::optional<std::array<GLenum, 4>> swizzleMask = std::nullopt;
 
         /// If true and the texture has a single Red channel, a swizzle mask of
         /// { GL_RED, GL_RED, GL_RED, GL_ONE } will be applied to the texture.
         /// If the swizzle mask is already set, this option is ignored
-        std::optional<bool> autoSwizzleGrayscale = std::nullopt;
+        bool autoSwizzleGrayscale = true;
     };
 
     /**

--- a/include/ghoul/opengl/texture.h
+++ b/include/ghoul/opengl/texture.h
@@ -155,6 +155,11 @@ public:
 
         /// Changes the general swizzle mask of the texture
         std::optional<std::array<GLenum, 4>> swizzleMask = std::nullopt;
+
+        /// If true and the texture has a single Red channel, a swizzle mask of
+        /// { GL_RED, GL_RED, GL_RED, GL_ONE } will be applied to the texture.
+        /// If the swizzle mask is already set, this option is ignored
+        std::optional<bool> autoSwizzleGrayscale = std::nullopt;
     };
 
     /**

--- a/src/io/texture/texturereader.cpp
+++ b/src/io/texture/texturereader.cpp
@@ -31,15 +31,15 @@
 #include <ghoul/opengl/texture.h>
 #include <stb_image.h>
 #include <cstring>
+#include <string_view>
 #include <utility>
 
 namespace {
     using namespace ghoul;
     using namespace ghoul::io::texture;
 
-    std::unique_ptr<opengl::Texture> load(unsigned char* data, int x, int y, int n,
-                                          const std::string& message, int nDimensions,
-                                          opengl::Texture::SamplerInit samplerSettings)
+    ImageInfo loadImageData(unsigned char* data, int x, int y, int n,
+                            std::string_view message)
     {
         if (!data) {
             throw TextureLoadException(
@@ -47,7 +47,6 @@ namespace {
                 std::format("Error reading image data: {}", stbi_failure_reason())
             );
         }
-
 
         // This is weird. stb_image.h says that the first pixel loaded is the one in the
         // upper left. However, if we load the data and just use it, the images are
@@ -68,6 +67,30 @@ namespace {
             std::memcpy(data + (y - i - 1) * x * n, buffer.data(), x * n);
         }
 
+        // Copy data into vector
+        std::vector<std::byte> vec(
+            reinterpret_cast<std::byte*>(data),
+            reinterpret_cast<std::byte*>(data) + (x * y * n)
+        );
+
+        // Done with the data, let's free it
+        stbi_image_free(data);
+
+        return {
+            .dimensions = glm::ivec2(x, y),
+            .nChannels = n,
+            .data = std::move(vec)
+        };
+    }
+
+    /**
+     * Load a texture object from the image data, using reasonable parameters based on the
+     * image dimensionality.
+     */
+    std::unique_ptr<opengl::Texture> makeTexture(ImageInfo info, std::string_view message,
+                                                 int nDimensions,
+                                             opengl::Texture::SamplerInit samplerSettings)
+    {
         const opengl::Texture::Format format = [](int nDim) {
             switch (nDim) {
                 case 1: return opengl::Texture::Format::Red;
@@ -76,8 +99,9 @@ namespace {
                 case 4: return opengl::Texture::Format::RGBA;
                 default:
                     throw RuntimeError(std::format("Unknown dimension '{}'", nDim));
-                }
-            }(n);
+            }
+        }(info.nChannels);
+
         const GLenum type = [](int d) {
             switch (d) {
                 case 1: return GL_TEXTURE_1D;
@@ -90,16 +114,15 @@ namespace {
 
         std::unique_ptr<opengl::Texture> texture =
             std::make_unique<opengl::Texture>(
-                opengl::Texture::FormatInit {
-                    .dimensions = glm::uvec3(x, y, 1),
+                opengl::Texture::FormatInit{
+                    .dimensions = glm::uvec3(info.dimensions.x, info.dimensions.y, 1),
                     .type = type,
                     .format = format,
                     .dataType = GL_UNSIGNED_BYTE
                 },
                 samplerSettings,
-                reinterpret_cast<std::byte*>(data)
+                reinterpret_cast<std::byte*>(info.data.data())
             );
-        stbi_image_free(data);
         return texture;
     }
 } // namespace
@@ -107,7 +130,7 @@ namespace {
 namespace ghoul::io::texture {
 
 MissingReaderException::MissingReaderException(std::string extension,
-                                                              std::filesystem::path file_)
+                                               std::filesystem::path file_)
     : RuntimeError(
         std::format(
             "No reader found for extension '{}' with file '{}'", extension, file_
@@ -134,12 +157,8 @@ InvalidLoadException::InvalidLoadException(void* memory, size_t size)
     , _size(size)
 {}
 
-std::unique_ptr<opengl::Texture> loadTexture(const std::filesystem::path& filename,
-                                                                          int nDimensions,
-                                             opengl::Texture::SamplerInit samplerSettings)
-{
+ImageInfo loadImage(const std::filesystem::path& filename) {
     ghoul_assert(!filename.empty(), "Filename must not be empty");
-    ghoul_assert(nDimensions >= 1 && nDimensions <= 3, "nDimensions must be 1, 2, or 3");
 
     std::string extension = std::filesystem::path(filename).extension().string();
     if (!extension.empty()) {
@@ -157,13 +176,10 @@ std::unique_ptr<opengl::Texture> loadTexture(const std::filesystem::path& filena
     int n = 0;
     unsigned char* data = stbi_load(f.c_str(), &x, &y, &n, 0);
 
-    return load(data, x, y, n, f, nDimensions, std::move(samplerSettings));
+    return loadImageData(data, x, y, n, f);
 }
 
-std::unique_ptr<opengl::Texture> loadTexture(void* memory, size_t size, int nDimensions,
-                                             opengl::Texture::SamplerInit samplerSettings,
-                                                                const std::string& format)
-{
+ImageInfo loadImage(void* memory, size_t size, const std::string& format) {
     ghoul_assert(memory, "Memory must not be nullptr");
     ghoul_assert(size > 0, "Size must be > 0");
 
@@ -183,7 +199,39 @@ std::unique_ptr<opengl::Texture> loadTexture(void* memory, size_t size, int nDim
         0
     );
 
-    return load(data, x, y, n, "Memory", nDimensions, std::move(samplerSettings));
+    return loadImageData(data, x, y, n, "Memory");
+}
+
+std::unique_ptr<opengl::Texture> loadTexture(const std::filesystem::path& filename,
+                                                                          int nDimensions,
+                                             opengl::Texture::SamplerInit samplerSettings)
+{
+    ghoul_assert(!filename.empty(), "Filename must not be empty");
+    ghoul_assert(nDimensions >= 1 && nDimensions <= 3, "nDimensions must be 1, 2, or 3");
+
+    ImageInfo info = loadImage(filename);
+
+    return makeTexture(
+        std::move(info),
+        filename.string(),
+        nDimensions,
+        std::move(samplerSettings)
+    );
+}
+
+
+std::unique_ptr<opengl::Texture> loadTexture(void* memory, size_t size, int nDimensions,
+                                             opengl::Texture::SamplerInit samplerSettings,
+                                                                const std::string& format)
+{
+    ImageInfo info = loadImage(memory, size, format);
+
+    return makeTexture(
+        std::move(info),
+        "Memory",
+        nDimensions,
+        std::move(samplerSettings)
+    );
 }
 
 glm::ivec2 imageSize(const std::filesystem::path& filename) {

--- a/src/io/texture/texturereader.cpp
+++ b/src/io/texture/texturereader.cpp
@@ -87,8 +87,7 @@ namespace {
      * Load a texture object from the image data, using reasonable parameters based on the
      * image dimensionality.
      */
-    std::unique_ptr<opengl::Texture> makeTexture(ImageInfo info, std::string_view message,
-                                                 int nDimensions,
+    std::unique_ptr<opengl::Texture> makeTexture(ImageInfo info, int nDimensions,
                                              opengl::Texture::SamplerInit samplerSettings)
     {
         const opengl::Texture::Format format = [](int nDim) {
@@ -213,12 +212,10 @@ std::unique_ptr<opengl::Texture> loadTexture(const std::filesystem::path& filena
 
     return makeTexture(
         std::move(info),
-        filename.string(),
         nDimensions,
         std::move(samplerSettings)
     );
 }
-
 
 std::unique_ptr<opengl::Texture> loadTexture(void* memory, size_t size, int nDimensions,
                                              opengl::Texture::SamplerInit samplerSettings,
@@ -228,13 +225,12 @@ std::unique_ptr<opengl::Texture> loadTexture(void* memory, size_t size, int nDim
 
     return makeTexture(
         std::move(info),
-        "Memory",
         nDimensions,
         std::move(samplerSettings)
     );
 }
 
-glm::ivec2 imageSize(const std::filesystem::path& filename) {
+ImageInfo imageInfo(const std::filesystem::path& filename) {
     std::string extension = std::filesystem::path(filename).extension().string();
     if (!extension.empty()) {
         extension = extension.substr(1);
@@ -251,7 +247,11 @@ glm::ivec2 imageSize(const std::filesystem::path& filename) {
     int n = 0;
     stbi_info(f.c_str(), &x, &y, &n);
 
-    return glm::ivec2(x, y);
+    return {
+        .dimensions = glm::ivec2(x, y),
+        .nChannels = n,
+        .data = {}
+    };
 }
 
 bool isSupportedReadExtension(const std::string& extension) {

--- a/src/io/texture/texturereader.cpp
+++ b/src/io/texture/texturereader.cpp
@@ -90,17 +90,6 @@ namespace {
     std::unique_ptr<opengl::Texture> makeTexture(ImageInfo info, int nDimensions,
                                              opengl::Texture::SamplerInit samplerSettings)
     {
-        const opengl::Texture::Format format = [](int nDim) {
-            switch (nDim) {
-                case 1: return opengl::Texture::Format::Red;
-                case 2: return opengl::Texture::Format::RG;
-                case 3: return opengl::Texture::Format::RGB;
-                case 4: return opengl::Texture::Format::RGBA;
-                default:
-                    throw RuntimeError(std::format("Unknown dimension '{}'", nDim));
-            }
-        }(info.nChannels);
-
         const GLenum type = [](int d) {
             switch (d) {
                 case 1: return GL_TEXTURE_1D;
@@ -116,7 +105,7 @@ namespace {
                 opengl::Texture::FormatInit{
                     .dimensions = glm::uvec3(info.dimensions.x, info.dimensions.y, 1),
                     .type = type,
-                    .format = format,
+                    .format = opengl::Texture::formatFromNumChannels(info.nChannels),
                     .dataType = GL_UNSIGNED_BYTE
                 },
                 samplerSettings,

--- a/src/opengl/texture.cpp
+++ b/src/opengl/texture.cpp
@@ -150,8 +150,7 @@ namespace {
             return *sampler.swizzleMask;
         }
 
-        bool shouldAutoSwizzle = sampler.autoSwizzleGrayscale.value_or(false);
-        if (shouldAutoSwizzle && format.format == Texture::Format::Red) {
+        if (sampler.autoSwizzleGrayscale && format.format == Texture::Format::Red) {
             return std::array<GLenum, 4>{ GL_RED, GL_RED, GL_RED, GL_ONE };
         }
 

--- a/src/opengl/texture.cpp
+++ b/src/opengl/texture.cpp
@@ -493,6 +493,19 @@ std::vector<std::byte> Texture::pixelData() const {
     return res;
 }
 
+Texture::Format Texture::formatFromNumChannels(int nChannels) {
+    switch (nChannels) {
+        case 1: return Texture::Format::Red;
+        case 2: return Texture::Format::RG;
+        case 3: return Texture::Format::RGB;
+        case 4: return Texture::Format::RGBA;
+        default:
+            throw ghoul::RuntimeError(
+                std::format("Unsupported channel count: {}", nChannels)
+            );
+    }
+}
+
 void Texture::downloadTexture() {
     if (!_pixels.empty()) {
         return;

--- a/src/opengl/texture.cpp
+++ b/src/opengl/texture.cpp
@@ -141,6 +141,23 @@ namespace {
         }
     }
 
+
+    std::optional<std::array<GLenum, 4>> parseSwizzleMask(
+                                                      const Texture::SamplerInit& sampler,
+                                                        const Texture::FormatInit& format)
+    {
+        if (sampler.swizzleMask.has_value()) {
+            return *sampler.swizzleMask;
+        }
+
+        bool shouldAutoSwizzle = sampler.autoSwizzleGrayscale.value_or(false);
+        if (shouldAutoSwizzle && format.format == Texture::Format::Red) {
+            return std::array<GLenum, 4>{ GL_RED, GL_RED, GL_RED, GL_ONE };
+        }
+
+        return std::nullopt;
+    }
+
     constexpr int nChannels(Texture::Format format) {
         switch (format) {
             case Texture::Format::Red:            return 1;
@@ -194,7 +211,7 @@ Texture::Texture(FormatInit format, SamplerInit sampler, const std::byte* data,
     , _filter(std::move(sampler.filter))
     , _wrapping(toWrappingModes(sampler.wrapping))
     , _borderColor(std::move(sampler.borderColor))
-    , _swizzleMask(std::move(sampler.swizzleMask))
+    , _swizzleMask(parseSwizzleMask(sampler, format))
     , _mipMapLevel(sampler.mipMapLevel.value_or(8))
     , _pixelAlignment(std::move(pixelAlignment))
 {


### PR DESCRIPTION
Adds functionality required to specify details for a `ghoul::Texture` object based on the information in the image. This is needed since the OpenGL update, as we can no longer edit the settings after the texture is created. So, now we sometimes need the loaded image's information before texture creation. 

Summary of changes
* Load functions in the texture reader that return the loaded image information and data, without creating a texture
* The `imageSize` function has been replaced with a function that also includes the number of channels in the image
* A `SamplerInit` setting to automatically add a swizzlemask for single-channel grayscale images
* A helper function to determine a recommended `Texture::Format` from the number of channels

Implemented in OpenSpace as part of: https://github.com/OpenSpace/OpenSpace/pull/3990