### PR TITLE
Always enable mip maps for models

### DIFF
--- a/src/io/model/modelreaderassimp.cpp
+++ b/src/io/model/modelreaderassimp.cpp
@@ -143,7 +143,9 @@ namespace {
                             static_cast<void*>(texture->pcData),
                             texture->mWidth,
                             2,
-                            {},
+                            opengl::Texture::SamplerInit{
+                                .filter = opengl::Texture::FilterMode::AnisotropicMipMap
+                            },
                             texture->achFormatHint
                         );
                         textureEntry.texture->setName(path.C_Str());
@@ -188,7 +190,10 @@ namespace {
 
                     textureEntry.texture = texture::loadTexture(
                         absPath(absolutePath),
-                        2
+                        2,
+                        opengl::Texture::SamplerInit{
+                            .filter = opengl::Texture::FilterMode::AnisotropicMipMap
+                        }
                     );
                     textureEntry.texture->setName(path.C_Str());
                     meshTexture.texture = textureEntry.texture.get();

--- a/src/io/model/modelreaderbinary.cpp
+++ b/src/io/model/modelreaderbinary.cpp
@@ -189,7 +189,9 @@ std::unique_ptr<modelgeometry::ModelGeometry> ModelReaderBinary::loadModel(
                 .dataType = dataType,
                 .internalFormat = internalFormat
             },
-            opengl::Texture::SamplerInit {},
+            opengl::Texture::SamplerInit{
+                .filter = opengl::Texture::FilterMode::AnisotropicMipMap
+            },
             data.data()
         );
         textureStorageArray.push_back(std::move(textureEntry));


### PR DESCRIPTION
Fixes issues with moire-like patterns for models with textures, as seen in the image testing 