### PR TITLE
Feature/model node animation

### DIFF
--- a/include/ghoul/io/model/modelgeometry.h
+++ b/include/ghoul/io/model/modelgeometry.h
@@ -74,9 +74,9 @@ public:
 
     void setTimeScale(float timeScale);
     void enableAnimation(bool value);
-    void updateCustomNodeTransform(const std::string& nodeName,
+    void updateCustomNodeTransform(std::string_view nodeName,
         const glm::dmat4& customTransform);
-    void setCustomTransformsOverride(bool customTransformsShouldOverride);
+    void setReplaceWithCustomTransforms(bool replaceWithCustomTransforms);
 
     void initialize();
     void deinitialize();
@@ -105,7 +105,7 @@ protected:
     std::unique_ptr<io::ModelAnimation> _animation;
     bool _hasCalcTransparency = false;
     bool _isTransparent = false;
-    bool _customTransformsShouldOverride = false;
+    bool _replaceWithCustomTransforms = false;
 };
 
 } // namespace ghoul::modelgeometry

--- a/include/ghoul/io/model/modelgeometry.h
+++ b/include/ghoul/io/model/modelgeometry.h
@@ -74,6 +74,8 @@ public:
 
     void setTimeScale(float timeScale);
     void enableAnimation(bool value);
+    void updateCustomNodeTransform(const glm::dmat4& customTransform,
+        const std::string& nodeName);
 
     void initialize();
     void deinitialize();

--- a/include/ghoul/io/model/modelgeometry.h
+++ b/include/ghoul/io/model/modelgeometry.h
@@ -75,7 +75,7 @@ public:
     void setTimeScale(float timeScale);
     void enableAnimation(bool value);
     void updateCustomNodeTransform(const glm::dmat4& customTransform,
-        const std::string& nodeName);
+        const std::string& nodeName, bool customTransformsShouldOverride);
 
     void initialize();
     void deinitialize();
@@ -104,6 +104,7 @@ protected:
     std::unique_ptr<io::ModelAnimation> _animation;
     bool _hasCalcTransparency = false;
     bool _isTransparent = false;
+    bool _customTransformsShouldOverride = false;
 };
 
 } // namespace ghoul::modelgeometry

--- a/include/ghoul/io/model/modelgeometry.h
+++ b/include/ghoul/io/model/modelgeometry.h
@@ -74,8 +74,9 @@ public:
 
     void setTimeScale(float timeScale);
     void enableAnimation(bool value);
-    void updateCustomNodeTransform(const glm::dmat4& customTransform,
-        const std::string& nodeName, bool customTransformsShouldOverride);
+    void updateCustomNodeTransform(const std::string& nodeName,
+        const glm::dmat4& customTransform);
+    void setCustomTransformsOverride(bool customTransformsShouldOverride);
 
     void initialize();
     void deinitialize();

--- a/include/ghoul/io/model/modelnode.h
+++ b/include/ghoul/io/model/modelnode.h
@@ -36,7 +36,7 @@ namespace ghoul::io {
 
 class ModelNode {
 public:
-    ModelNode(glm::mat4 transform, std::vector<io::ModelMesh> meshes);
+    ModelNode(std::string name, glm::mat4 transform, std::vector<io::ModelMesh> meshes);
 
     ModelNode(ModelNode&&) noexcept = default;
     ~ModelNode() noexcept = default;
@@ -45,6 +45,7 @@ public:
     void setChildren(std::vector<int> children);
     void addChild(int child);
     void setAnimation(const glm::mat4& animation);
+    void updateCustomTransform(const glm::dmat4& customTransform);
 
     std::vector<io::ModelMesh>& meshes();
     const std::vector<io::ModelMesh>& meshes() const;
@@ -53,7 +54,10 @@ public:
     const std::vector<int>& children() const;
     glm::mat4 transform() const;
     glm::mat4 animationTransform() const;
+    glm::mat4 customTransform() const;
     bool hasAnimation() const;
+    bool hasCustomTransform() const;
+    std::string name() const;
 
 private:
     // `glm::mat4` is not noexcept move constructable, use an array instead for transform
@@ -70,10 +74,18 @@ private:
         0.f, 0.f, 1.f, 0.f,
         0.f, 0.f, 0.f, 1.f
     };
+    std::array<GLfloat, 16> _customTransform = {
+        1.f, 0.f, 0.f, 0.f,
+        0.f, 1.f, 0.f, 0.f,
+        0.f, 0.f, 1.f, 0.f,
+        0.f, 0.f, 0.f, 1.f
+    };
     std::vector<ModelMesh> _meshes;
     int _parent = -1;
     std::vector<int> _children;
     bool _hasAnimation = false;
+    bool _hasCustomTransform = false;
+    std::string _name;
 };
 
 } // namespace ghoul::io

--- a/include/ghoul/io/model/modelreader.h
+++ b/include/ghoul/io/model/modelreader.h
@@ -108,7 +108,6 @@ public:
      */
     void addReader(std::unique_ptr<ModelReaderBase> reader);
 
-private:
     /**
      * Returns the ModelReaderBase that is responsible for the provided extension.
      *
@@ -118,6 +117,7 @@ private:
      */
     ModelReaderBase* readerForExtension(const std::string& extension);
 
+private:
     /// The list of all registered readers
     std::vector<std::unique_ptr<ModelReaderBase>> _readers;
 };

--- a/include/ghoul/io/model/modelreaderassimp.h
+++ b/include/ghoul/io/model/modelreaderassimp.h
@@ -64,6 +64,15 @@ public:
         bool notifyInvisibleDropped = true) const override;
 
     /**
+     * Prints the model tree of the model file pointed to by \p filename to the info log.
+     * This is useful for identifying the structure of the model and the names of the
+     * nodes, which can be used for custom node transformations and animations.
+     *
+     * \param filename The geometric model file to print the model tree for
+     */
+    void printModelTree(const std::filesystem::path& filename) const;
+
+    /**
      * Returns if this reader needs a cache file or not.
      *
      * \return A boolean for if this reader needs a cache file or not

--- a/include/ghoul/io/model/modelreaderassimp.h
+++ b/include/ghoul/io/model/modelreaderassimp.h
@@ -64,13 +64,13 @@ public:
         bool notifyInvisibleDropped = true) const override;
 
     /**
-     * Prints the model tree of the model file pointed to by \p filename to the info log.
+     * Prints the model tree of the model file pointed to by \p filepath to the info log.
      * This is useful for identifying the structure of the model and the names of the
      * nodes, which can be used for custom node transformations and animations.
      *
-     * \param filename The geometric model file to print the model tree for
+     * \param filepath The geometric model file to print the model tree for
      */
-    void printModelTree(const std::filesystem::path& filename) const;
+    void printModelTree(const std::filesystem::path& filepath) const;
 
     /**
      * Returns if this reader needs a cache file or not.

--- a/src/io/model/modelgeometry.cpp
+++ b/src/io/model/modelgeometry.cpp
@@ -133,14 +133,13 @@ namespace {
     void renderRecursive(const std::vector<io::ModelNode>& nodes,
                          const io::ModelNode* node, opengl::ProgramObject& program,
                          const glm::mat4& parentTransform, bool isFullyTexturedModel,
-                         bool isProjection, bool customTransformsShouldOverride)
+                         bool isProjection, bool replaceWithCustomTransforms)
     {
         if (!node) {
             LERROR("Cannot render empty node");
             return;
         }
 
-        glm::mat4 globalTransform;
         glm::mat4 animationTransform = glm::mat4(1.f);
         glm::mat4 customTransform = glm::mat4(1.f);
         glm::mat4 nodeTransform = node->transform();
@@ -153,14 +152,15 @@ namespace {
         }
 
         if (node->hasCustomTransform()) {
-            if (customTransformsShouldOverride) {
+            if (replaceWithCustomTransforms) {
                 nodeTransform = glm::mat4(1.f);
             }
 
             customTransform = node->customTransform();
         }
 
-        globalTransform = parentTransform * animationTransform * customTransform * nodeTransform;
+        glm::mat4 globalTransform =
+            parentTransform * animationTransform * customTransform * nodeTransform;
 
         for (const io::ModelMesh& mesh : node->meshes()) {
             mesh.render(program, globalTransform, isFullyTexturedModel, isProjection);
@@ -174,7 +174,7 @@ namespace {
                 globalTransform,
                 isFullyTexturedModel,
                 isProjection,
-                customTransformsShouldOverride
+                replaceWithCustomTransforms
             );
         }
     }
@@ -523,10 +523,7 @@ std::unique_ptr<modelgeometry::ModelGeometry> ModelGeometry::loadCacheFile(
         }
         std::string name;
         name.resize(nChars);
-        fileStream.read(
-            reinterpret_cast<char*>(name.data()),
-            nChars * sizeof(char)
-        );
+        fileStream.read(reinterpret_cast<char*>(name.data()), nChars * sizeof(char));
 
         // Create Node
         io::ModelNode node = io::ModelNode(
@@ -914,7 +911,10 @@ bool ModelGeometry::saveToCacheFile(const std::filesystem::path& cachedFile) con
         std::string name = node.name();
         int32_t nChars = static_cast<int32_t>(name.size());
         fileStream.write(reinterpret_cast<const char*>(&nChars), sizeof(int32_t));
-        fileStream.write(reinterpret_cast<const char*>(name.data()), nChars * sizeof(char));
+        fileStream.write(
+            reinterpret_cast<const char*>(name.data()),
+            nChars * sizeof(char)
+        );
     }
 
     // Animation
@@ -1161,7 +1161,7 @@ void ModelGeometry::render(opengl::ProgramObject& program, bool isFullyTexturedM
         parentTransform,
         isFullyTexturedModel,
         isProjection,
-        _customTransformsShouldOverride
+        _replaceWithCustomTransforms
     );
 }
 
@@ -1191,7 +1191,7 @@ void ModelGeometry::enableAnimation(bool value) {
     }
 }
 
-void ModelGeometry::updateCustomNodeTransform(const std::string& nodeName,
+void ModelGeometry::updateCustomNodeTransform(std::string_view nodeName,
                                               const glm::dmat4& customTransform)
 {
     for (io::ModelNode& node : _nodes) {
@@ -1202,13 +1202,12 @@ void ModelGeometry::updateCustomNodeTransform(const std::string& nodeName,
     }
 
     LERROR(std::format(
-        "Could not find node with name '{}' to update custom transform",
-        nodeName
+        "Could not find node with name '{}' to update custom transform", nodeName
     ));
 }
 
-void ModelGeometry::setCustomTransformsOverride(bool customTransformsShouldOverride) {
-    _customTransformsShouldOverride = customTransformsShouldOverride;
+void ModelGeometry::setReplaceWithCustomTransforms(bool replaceWithCustomTransforms) {
+    _replaceWithCustomTransforms = replaceWithCustomTransforms;
 }
 
 void ModelGeometry::initialize() {

--- a/src/io/model/modelgeometry.cpp
+++ b/src/io/model/modelgeometry.cpp
@@ -149,6 +149,7 @@ namespace {
             // Animation is given by Assimp in absolute format, i.e. animation replaces
             // old transform
             animationTransform = node->animationTransform();
+            nodeTransform = glm::mat4(1.f);
         }
 
         if (node->hasCustomTransform()) {
@@ -1190,13 +1191,11 @@ void ModelGeometry::enableAnimation(bool value) {
     }
 }
 
-void ModelGeometry::updateCustomNodeTransform(const glm::dmat4& customTransform,
-                                              const std::string& nodeName,
-                                              bool customTransformsShouldOverride)
+void ModelGeometry::updateCustomNodeTransform(const std::string& nodeName,
+                                              const glm::dmat4& customTransform)
 {
     for (io::ModelNode& node : _nodes) {
         if (node.name() == nodeName) {
-            _customTransformsShouldOverride = customTransformsShouldOverride;
             node.updateCustomTransform(customTransform);
             return;
         }
@@ -1206,6 +1205,10 @@ void ModelGeometry::updateCustomNodeTransform(const glm::dmat4& customTransform,
         "Could not find node with name '{}' to update custom transform",
         nodeName
     ));
+}
+
+void ModelGeometry::setCustomTransformsOverride(bool customTransformsShouldOverride) {
+    _customTransformsShouldOverride = customTransformsShouldOverride;
 }
 
 void ModelGeometry::initialize() {

--- a/src/io/model/modelgeometry.cpp
+++ b/src/io/model/modelgeometry.cpp
@@ -133,7 +133,7 @@ namespace {
     void renderRecursive(const std::vector<io::ModelNode>& nodes,
                          const io::ModelNode* node, opengl::ProgramObject& program,
                          const glm::mat4& parentTransform, bool isFullyTexturedModel,
-                         bool isProjection)
+                         bool isProjection, bool customTransformsShouldOverride)
     {
         if (!node) {
             LERROR("Cannot render empty node");
@@ -141,18 +141,25 @@ namespace {
         }
 
         glm::mat4 globalTransform;
+        glm::mat4 animationTransform = glm::mat4(1.f);
+        glm::mat4 customTransform = glm::mat4(1.f);
+        glm::mat4 nodeTransform = node->transform();
+
         if (node->hasAnimation()) {
             // Animation is given by Assimp in absolute format, i.e. animation replaces
             // old transform
-            globalTransform = parentTransform * node->animationTransform();
+            animationTransform = node->animationTransform();
         }
-        else if (node->hasCustomTransform()) {
-            // Custom transform is applied on top of the normal transform
-            globalTransform = parentTransform * node->customTransform() * node->transform();
+
+        if (node->hasCustomTransform()) {
+            if (customTransformsShouldOverride) {
+                nodeTransform = glm::mat4(1.f);
+            }
+
+            customTransform = node->customTransform();
         }
-        else {
-            globalTransform = parentTransform * node->transform();
-        }
+
+        globalTransform = parentTransform * animationTransform * customTransform * nodeTransform;
 
         for (const io::ModelMesh& mesh : node->meshes()) {
             mesh.render(program, globalTransform, isFullyTexturedModel, isProjection);
@@ -165,7 +172,8 @@ namespace {
                 program,
                 globalTransform,
                 isFullyTexturedModel,
-                isProjection
+                isProjection,
+                customTransformsShouldOverride
             );
         }
     }
@@ -1151,7 +1159,8 @@ void ModelGeometry::render(opengl::ProgramObject& program, bool isFullyTexturedM
         program,
         parentTransform,
         isFullyTexturedModel,
-        isProjection
+        isProjection,
+        _customTransformsShouldOverride
     );
 }
 
@@ -1182,10 +1191,12 @@ void ModelGeometry::enableAnimation(bool value) {
 }
 
 void ModelGeometry::updateCustomNodeTransform(const glm::dmat4& customTransform,
-                                              const std::string& nodeName)
+                                              const std::string& nodeName,
+                                              bool customTransformsShouldOverride)
 {
     for (io::ModelNode& node : _nodes) {
         if (node.name() == nodeName) {
+            _customTransformsShouldOverride = customTransformsShouldOverride;
             node.updateCustomTransform(customTransform);
             return;
         }

--- a/src/io/model/modelgeometry.cpp
+++ b/src/io/model/modelgeometry.cpp
@@ -45,7 +45,7 @@ namespace {
     using namespace ghoul;
 
     constexpr std::string_view _loggerCat = "ModelGeometry";
-    constexpr int8_t CurrentCacheVersion = 11;
+    constexpr int8_t CurrentCacheVersion = 12;
     constexpr int FormatStringSize = 4;
     constexpr int8_t ShouldSkipMarker = -1;
     constexpr int8_t NoSkipMarker = 1;
@@ -145,6 +145,10 @@ namespace {
             // Animation is given by Assimp in absolute format, i.e. animation replaces
             // old transform
             globalTransform = parentTransform * node->animationTransform();
+        }
+        else if (node->hasCustomTransform()) {
+            // Custom transform is applied on top of the normal transform
+            globalTransform = parentTransform * node->customTransform() * node->transform();
         }
         else {
             globalTransform = parentTransform * node->transform();
@@ -498,8 +502,29 @@ std::unique_ptr<modelgeometry::ModelGeometry> ModelGeometry::loadCacheFile(
         fileStream.read(reinterpret_cast<char*>(&a), sizeof(uint8_t));
         const bool hasAnimation = (a == 1);
 
+        // Name
+        int32_t nChars = 0;
+        fileStream.read(reinterpret_cast<char*>(&nChars), sizeof(int32_t));
+        if (nChars < 0) {
+            std::string message = std::format(
+                "Model node name cannot have negative number of characters while loading "
+                "cache: {}", nChars
+            );
+            throw ModelCacheException(cachedFile, message);
+        }
+        std::string name;
+        name.resize(nChars);
+        fileStream.read(
+            reinterpret_cast<char*>(name.data()),
+            nChars * sizeof(char)
+        );
+
         // Create Node
-        io::ModelNode node = io::ModelNode(std::move(transform), std::move(meshArray));
+        io::ModelNode node = io::ModelNode(
+            name,
+            std::move(transform),
+            std::move(meshArray)
+        );
         node.setChildren(std::move(childrenArray));
         node.setParent(parent);
         if (hasAnimation) {
@@ -875,6 +900,12 @@ bool ModelGeometry::saveToCacheFile(const std::filesystem::path& cachedFile) con
         // HasAnimation
         uint8_t a = node.hasAnimation() ? 1 : 0;
         fileStream.write(reinterpret_cast<const char*>(&a), sizeof(uint8_t));
+
+        // Name
+        std::string name = node.name();
+        int32_t nChars = static_cast<int32_t>(name.size());
+        fileStream.write(reinterpret_cast<const char*>(&nChars), sizeof(int32_t));
+        fileStream.write(reinterpret_cast<const char*>(name.data()), nChars * sizeof(char));
     }
 
     // Animation
@@ -1148,6 +1179,22 @@ void ModelGeometry::enableAnimation(bool value) {
     if (!value) {
         _animation->reset(_nodes);
     }
+}
+
+void ModelGeometry::updateCustomNodeTransform(const glm::dmat4& customTransform,
+                                              const std::string& nodeName)
+{
+    for (io::ModelNode& node : _nodes) {
+        if (node.name() == nodeName) {
+            node.updateCustomTransform(customTransform);
+            return;
+        }
+    }
+
+    LERROR(std::format(
+        "Could not find node with name '{}' to update custom transform",
+        nodeName
+    ));
 }
 
 void ModelGeometry::initialize() {

--- a/src/io/model/modelnode.cpp
+++ b/src/io/model/modelnode.cpp
@@ -29,8 +29,10 @@
 
 namespace ghoul::io {
 
-ModelNode::ModelNode(glm::mat4 transform, std::vector<io::ModelMesh> meshes)
+ModelNode::ModelNode(std::string name, glm::mat4 transform,
+                     std::vector<io::ModelMesh> meshes)
     : _meshes(std::move(meshes))
+    , _name(std::move(name))
 {
     // GLM is column major, array is column major too
     _transform[0] = transform[0][0];
@@ -91,6 +93,31 @@ void ModelNode::setAnimation(const glm::mat4& animation) {
     _hasAnimation = true;
 }
 
+void ModelNode::updateCustomTransform(const glm::dmat4& customTransform) {
+    // GLM is column major, array is column major too
+    _customTransform[0] = customTransform[0][0];
+    _customTransform[1] = customTransform[0][1];
+    _customTransform[2] = customTransform[0][2];
+    _customTransform[3] = customTransform[0][3];
+
+    _customTransform[4] = customTransform[1][0];
+    _customTransform[5] = customTransform[1][1];
+    _customTransform[6] = customTransform[1][2];
+    _customTransform[7] = customTransform[1][3];
+
+    _customTransform[8] = customTransform[2][0];
+    _customTransform[9] = customTransform[2][1];
+    _customTransform[10] = customTransform[2][2];
+    _customTransform[11] = customTransform[2][3];
+
+    _customTransform[12] = customTransform[3][0];
+    _customTransform[13] = customTransform[3][1];
+    _customTransform[14] = customTransform[3][2];
+    _customTransform[15] = customTransform[3][3];
+
+    _hasCustomTransform = true;
+}
+
 std::vector<io::ModelMesh>& ModelNode::meshes() {
     return _meshes;
 }
@@ -119,8 +146,20 @@ glm::mat4 ModelNode::animationTransform() const {
     return glm::make_mat4(_animationTransform.data());
 }
 
+glm::mat4 ModelNode::customTransform() const {
+    return glm::make_mat4(_customTransform.data());
+}
+
 bool ModelNode::hasAnimation() const {
     return _hasAnimation;
+}
+
+bool ModelNode::hasCustomTransform() const {
+    return _hasCustomTransform;
+}
+
+std::string ModelNode::name() const {
+    return _name;
 }
 
 } // namespace ghoul::io

--- a/src/io/model/modelreaderassimp.cpp
+++ b/src/io/model/modelreaderassimp.cpp
@@ -829,20 +829,20 @@ std::unique_ptr<modelgeometry::ModelGeometry> ModelReaderAssimp::loadModel(
     );
 }
 
-void ModelReaderAssimp::printModelTree(const std::filesystem::path& filename) const {
+void ModelReaderAssimp::printModelTree(const std::filesystem::path& filepath) const {
     Assimp::Importer importer;
     const aiScene* scene = importer.ReadFile(
-        filename.string(),
+        filepath.string(),
         aiProcess_Triangulate |       // Only triangles
         aiProcess_GenSmoothNormals |  // Generate smooth normals
         aiProcess_CalcTangentSpace    // Generate tangents and bitangents
     );
 
     if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode) {
-        throw ModelLoadException(filename, importer.GetErrorString(), this);
+        throw ModelLoadException(filepath, importer.GetErrorString(), this);
     }
 
-    LINFO(std::format("Model tree for '{}':", filename));
+    LINFO(std::format("Model tree for '{}':", filepath));
     printModelTreeRecursive(
         *(scene->mRootNode),
         *scene

--- a/src/io/model/modelreaderassimp.cpp
+++ b/src/io/model/modelreaderassimp.cpp
@@ -58,6 +58,7 @@ namespace {
     using namespace ghoul::io;
 
     constexpr std::string_view _loggerCat = "ModelReaderAssimp";
+    constexpr int TreeTabLength = 2;
 
     bool isTextureTransparent(const ModelMesh::Texture& texture) {
         const int nChannels = texture.texture->numberOfChannels();
@@ -608,8 +609,8 @@ namespace {
                 nodeName = nodeMesh->mName.C_Str();
             }
         }
-        ModelNode modelNode(nodeName.c_str(), nodeTransform, std::move(meshArray));
 
+        ModelNode modelNode(nodeName.c_str(), nodeTransform, std::move(meshArray));
         modelNode.setParent(parent);
         nodes.push_back(std::move(modelNode));
         const int newNode = static_cast<int>(nodes.size() - 1);
@@ -711,6 +712,37 @@ namespace {
             );
         }
     }
+
+    void printModelTreeRecursive(const aiNode& node, const aiScene& scene,
+                                 const std::string& prefix = "")
+    {
+        // When the name field of a node is missing, it is replaced by Assimp with the
+        // string "nodes[{i}]". Blender, for example, will automatically replace that
+        // auto-generated name with the name of the contained mesh, if there is only one.
+        // For consistency with Blender, we do the same here.
+        std::string nodeName = node.mName.C_Str();
+        const bool hasSyntheticName =
+            nodeName.starts_with("nodes[") && nodeName.ends_with(']');
+        if (hasSyntheticName && node.mNumMeshes == 1) {
+            const aiMesh* nodeMesh = scene.mMeshes[node.mMeshes[0]];
+            if (nodeMesh && nodeMesh->mName.length > 0) {
+                nodeName = nodeMesh->mName.C_Str();
+            }
+        }
+
+        // Print the name of this node, the parent
+        LINFO(std::format("{}{}", prefix, nodeName));
+
+        // Then print the name of the children nodes with increased prefix
+        for (unsigned int i = 0; i < node.mNumChildren; i++) {
+            printModelTreeRecursive(
+                *(node.mChildren[i]),
+                scene,
+                std::string(prefix.size() + TreeTabLength, ' ')
+            );
+        }
+    }
+
 } // namespace
 
 namespace ghoul::io {
@@ -794,6 +826,26 @@ std::unique_ptr<modelgeometry::ModelGeometry> ModelReaderAssimp::loadModel(
         std::move(nodeArray),
         std::move(textureStorage),
         std::move(modelAnimation)
+    );
+}
+
+void ModelReaderAssimp::printModelTree(const std::filesystem::path& filename) const {
+    Assimp::Importer importer;
+    const aiScene* scene = importer.ReadFile(
+        filename.string(),
+        aiProcess_Triangulate |       // Only triangles
+        aiProcess_GenSmoothNormals |  // Generate smooth normals
+        aiProcess_CalcTangentSpace    // Generate tangents and bitangents
+    );
+
+    if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode) {
+        throw ModelLoadException(filename, importer.GetErrorString(), this);
+    }
+
+    LINFO(std::format("Model tree for '{}':", filename));
+    printModelTreeRecursive(
+        *(scene->mRootNode),
+        *scene
     );
 }
 

--- a/src/io/model/modelreaderassimp.cpp
+++ b/src/io/model/modelreaderassimp.cpp
@@ -595,7 +595,21 @@ namespace {
             meshArray.push_back(std::move(loadedMesh));
         }
 
-        ModelNode modelNode(node.mName.C_Str(), nodeTransform, std::move(meshArray));
+        // When the name field of a node is missing, it is replaced by Assimp with the
+        // string "nodes[{i}]". Blender, for example, will automatically replace that
+        // auto-generated name with the name of the contained mesh, if there is only one.
+        // For consistency with Blender, we do the same here.
+        std::string nodeName = node.mName.C_Str();
+        const bool hasSyntheticName =
+            nodeName.starts_with("nodes[") && nodeName.ends_with(']');
+        if (hasSyntheticName && node.mNumMeshes == 1) {
+            const aiMesh* nodeMesh = scene.mMeshes[node.mMeshes[0]];
+            if (nodeMesh && nodeMesh->mName.length > 0) {
+                nodeName = nodeMesh->mName.C_Str();
+            }
+        }
+        ModelNode modelNode(nodeName.c_str(), nodeTransform, std::move(meshArray));
+
         modelNode.setParent(parent);
         nodes.push_back(std::move(modelNode));
         const int newNode = static_cast<int>(nodes.size() - 1);

--- a/src/io/model/modelreaderassimp.cpp
+++ b/src/io/model/modelreaderassimp.cpp
@@ -595,7 +595,7 @@ namespace {
             meshArray.push_back(std::move(loadedMesh));
         }
 
-        ModelNode modelNode(nodeTransform, std::move(meshArray));
+        ModelNode modelNode(node.mName.C_Str(), nodeTransform, std::move(meshArray));
         modelNode.setParent(parent);
         nodes.push_back(std::move(modelNode));
         const int newNode = static_cast<int>(nodes.size() - 1);

--- a/src/io/model/modelreaderbinary.cpp
+++ b/src/io/model/modelreaderbinary.cpp
@@ -41,7 +41,7 @@ namespace {
     using namespace ghoul;
 
     constexpr std::string_view _loggerCat = "ModelReaderBinary";
-    constexpr int8_t CurrentModelVersion = 10;
+    constexpr int8_t CurrentModelVersion = 12;
     constexpr int FormatStringSize = 4;
     constexpr int8_t ShouldSkipMarker = -1;
 
@@ -50,6 +50,8 @@ namespace {
     constexpr int8_t OpacityUpdateVersion = 8;
     constexpr int8_t VertexColorUpdateVersion = 9;
     constexpr int8_t SkipMarkerUpdateVersion = 10;
+    constexpr int8_t ImmutableTexturesVersion = 11; // No file format difference from 10
+    constexpr int8_t NodeNameUpdateVersion = 12;
 
     opengl::Texture::Format stringToFormat(std::string_view format) {
         using Format = opengl::Texture::Format;
@@ -95,9 +97,10 @@ std::unique_ptr<modelgeometry::ModelGeometry> ModelReaderBinary::loadModel(
     int8_t version = 0;
     fileStream.read(reinterpret_cast<char*>(&version), sizeof(int8_t));
     if (version != CurrentModelVersion &&
-        // Backward compatible versions are ok
+        // Backward compatible versions that are ok
         version != AnimationUpdateVersion && version != OpacityUpdateVersion &&
-        version != VertexColorUpdateVersion && version != SkipMarkerUpdateVersion)
+        version != VertexColorUpdateVersion && version != SkipMarkerUpdateVersion &&
+        version != ImmutableTexturesVersion && version != NodeNameUpdateVersion)
     {
         throw ModelLoadException(
             filename,
@@ -419,8 +422,31 @@ std::unique_ptr<modelgeometry::ModelGeometry> ModelReaderBinary::loadModel(
         fileStream.read(reinterpret_cast<char*>(&a), sizeof(uint8_t));
         const bool hasAnimation = (a == 1);
 
+        // Name
+        std::string name = "";
+        if (version >= NodeNameUpdateVersion) {
+            int32_t nChars = 0;
+            fileStream.read(reinterpret_cast<char*>(&nChars), sizeof(int32_t));
+            if (nChars < 0) {
+                std::string message = std::format(
+                    "Model node name cannot have negative number of characters: {}",
+                    nChars
+                );
+                throw ModelLoadException(filename, message, this);
+            }
+            name.resize(nChars);
+            fileStream.read(
+                reinterpret_cast<char*>(name.data()),
+                nChars * sizeof(char)
+            );
+        }
+
         // Create Node
-        io::ModelNode node = io::ModelNode(std::move(transform), std::move(meshArray));
+        io::ModelNode node = io::ModelNode(
+            name,
+            std::move(transform),
+            std::move(meshArray)
+        );
         node.setChildren(std::move(childrenArray));
         node.setParent(parent);
         if (hasAnimation) {

--- a/src/io/model/modelreaderbinary.cpp
+++ b/src/io/model/modelreaderbinary.cpp
@@ -423,7 +423,7 @@ std::unique_ptr<modelgeometry::ModelGeometry> ModelReaderBinary::loadModel(
         const bool hasAnimation = (a == 1);
 
         // Name
-        std::string name = "";
+        std::string name;
         if (version >= NodeNameUpdateVersion) {
             int32_t nChars = 0;
             fileStream.read(reinterpret_cast<char*>(&nChars), sizeof(int32_t));
@@ -435,10 +435,7 @@ std::unique_ptr<modelgeometry::ModelGeometry> ModelReaderBinary::loadModel(
                 throw ModelLoadException(filename, message, this);
             }
             name.resize(nChars);
-            fileStream.read(
-                reinterpret_cast<char*>(name.data()),
-                nChars * sizeof(char)
-            );
+            fileStream.read(reinterpret_cast<char*>(name.data()), nChars * sizeof(char));
         }
 
         // Create Node


### PR DESCRIPTION
This makes it possible to add a transformation to an internal model node for a 3D model. This also requires all nodes to store the name, therefor the caching format has been updated. The user can choose to either replace the existing transformation with the custom one or add it on top of the existing one with a parameter. 

EDIT:
There is also a new function to print the model tree to help with finding the correct names for nodes to apply a custom transformation to. 