### PR TITLE
Feature/networking issues

### DIFF
--- a/include/ghoul/io/socket/tcpsocket.h
+++ b/include/ghoul/io/socket/tcpsocket.h
@@ -79,6 +79,7 @@ public:
       * themselves (unlike disconnect())
       */
     void closeConnection();
+    void waitForOuputQueueDrained();
 
     // Methods for binary communication
     template <typename T = char>

--- a/include/ghoul/io/socket/tcpsocket.h
+++ b/include/ghoul/io/socket/tcpsocket.h
@@ -75,7 +75,7 @@ public:
 
      /**
       * Non-blocking counterpart to disconnect(), stops the I/O loops and closes the
-      * socket,  but does not join the threads. Safe tocall from within those threads
+      * socket, but does not join the threads. Safe tocall from within those threads
       * themselves (unlike disconnect())
       */
     void closeConnection();

--- a/include/ghoul/io/socket/tcpsocket.h
+++ b/include/ghoul/io/socket/tcpsocket.h
@@ -73,12 +73,16 @@ public:
     void interceptInput(InputInterceptor interceptor);
     void uninterceptInput();
 
-     /**
-      * Non-blocking counterpart to disconnect(), stops the I/O loops and closes the
-      * socket, but does not join the threads. Safe to call from within those threads
-      * themselves (unlike disconnect())
-      */
+    /**
+     * Non-blocking counterpart to disconnect(). Stops the I/O loops and closes the
+     * socket, but does not join the threads. Safe to call from within those threads
+     * themselves (unlike disconnect())
+     */
     void closeConnection();
+
+    /**
+     * Waits for the socket output to be emptied, or until the timeout is reached
+     */
     bool waitForOutputQueueDrained(std::chrono::milliseconds timeout);
 
     // Methods for binary communication

--- a/include/ghoul/io/socket/tcpsocket.h
+++ b/include/ghoul/io/socket/tcpsocket.h
@@ -79,7 +79,7 @@ public:
       * themselves (unlike disconnect())
       */
     void closeConnection();
-    void waitForOuputQueueDrained();
+    bool waitForOutputQueueDrained(std::chrono::milliseconds timeout);
 
     // Methods for binary communication
     template <typename T = char>

--- a/include/ghoul/io/socket/tcpsocket.h
+++ b/include/ghoul/io/socket/tcpsocket.h
@@ -75,7 +75,7 @@ public:
 
      /**
       * Non-blocking counterpart to disconnect(), stops the I/O loops and closes the
-      * socket, but does not join the threads. Safe tocall from within those threads
+      * socket, but does not join the threads. Safe to call from within those threads
       * themselves (unlike disconnect())
       */
     void closeConnection();

--- a/include/ghoul/io/socket/tcpsocket.h
+++ b/include/ghoul/io/socket/tcpsocket.h
@@ -73,6 +73,13 @@ public:
     void interceptInput(InputInterceptor interceptor);
     void uninterceptInput();
 
+     /**
+      * Non-blocking counterpart to disconnect(), stops the I/O loops and closes the
+      * socket,  but does not join the threads. Safe tocall from within those threads
+      * themselves (unlike disconnect())
+      */
+    void closeConnection();
+
     // Methods for binary communication
     template <typename T = char>
     bool get(T* buffer, size_t nItems = 1);

--- a/include/ghoul/io/socket/websocket.h
+++ b/include/ghoul/io/socket/websocket.h
@@ -115,6 +115,7 @@ private:
     std::condition_variable _inputNotifier;
 
     std::unique_ptr<TcpSocket> _tcpSocket;
+    bool _isMarkedForClosing = false;
 };
 
 } // namespace ghoul::io

--- a/src/io/socket/tcpsocket.cpp
+++ b/src/io/socket/tcpsocket.cpp
@@ -282,7 +282,7 @@ void TcpSocket::streamInput() {
         auto failed = [](int nBytes) { return nBytes <= 0; };
 #else // ^^^^ WIN32 // !WIN32 vvvv
         ssize_t nReadBytes = 0;
-        auto failed = [](ssize_t nBytes) { return nBytes == ssize_t(-1); };
+        auto failed = [](ssize_t nBytes) { return nBytes <= 0; };
 #endif // WIN32
 
         nReadBytes = recv(

--- a/src/io/socket/tcpsocket.cpp
+++ b/src/io/socket/tcpsocket.cpp
@@ -453,10 +453,11 @@ void TcpSocket::closeConnection() {
     _outputNotifier.notify_all();
 }
 
-void TcpSocket::waitForOuputQueueDrained() {
+bool TcpSocket::waitForOutputQueueDrained(std::chrono::milliseconds timeout) {
     std::unique_lock lock(_outputQueueMutex);
-    _outputNotifier.wait(
+    return _outputNotifier.wait_for(
         lock,
+        timeout,
         [this]() {
             return _outputQueue.empty() || _shouldStopThreads ||
                 (!_isConnected && !_isConnecting);

--- a/src/io/socket/tcpsocket.cpp
+++ b/src/io/socket/tcpsocket.cpp
@@ -350,6 +350,7 @@ void TcpSocket::streamOutput() {
             }
             _outputQueue.erase(_outputQueue.begin(), _outputQueue.begin() + nBytesToSend);
         }
+        _outputNotifier.notify_all(); // Let anyone waiting on drainage know
     }
 }
 
@@ -450,6 +451,17 @@ void TcpSocket::closeConnection() {
     closeSocket();
     _inputNotifier.notify_all();
     _outputNotifier.notify_all();
+}
+
+void TcpSocket::waitForOuputQueueDrained() {
+    std::unique_lock lock(_outputQueueMutex);
+    _outputNotifier.wait(
+        lock,
+        [this]() {
+            return _outputQueue.empty() || _shouldStopThreads ||
+                (!_isConnected && !_isConnecting);
+        }
+    );
 }
 
 bool TcpSocket::getBytes(char* buffer, size_t nItems) {

--- a/src/io/socket/tcpsocket.cpp
+++ b/src/io/socket/tcpsocket.cpp
@@ -338,7 +338,7 @@ void TcpSocket::streamOutput() {
                 nBytesToSend,
                 0
             );
-            auto failed = [](ssize_t nBytes) { return nBytes == ssize_t(-1); };
+            auto failed = [](ssize_t nBytes) { return nBytes <= 0; };
 #endif // WIN32
 
             if (failed(nSentBytes)) {
@@ -348,7 +348,7 @@ void TcpSocket::streamOutput() {
                 _outputNotifier.notify_all();
                 return;
             }
-            _outputQueue.erase(_outputQueue.begin(), _outputQueue.begin() + nBytesToSend);
+            _outputQueue.erase(_outputQueue.begin(), _outputQueue.begin() + nSentBytes);
         }
         _outputNotifier.notify_all(); // Let anyone waiting on drainage know
     }

--- a/src/io/socket/tcpsocket.cpp
+++ b/src/io/socket/tcpsocket.cpp
@@ -445,6 +445,13 @@ void TcpSocket::uninterceptInput() {
     _inputInterceptor = nullptr;
 }
 
+void TcpSocket::closeConnection() {
+    _shouldStopThreads = true;
+    closeSocket();
+    _inputNotifier.notify_all();
+    _outputNotifier.notify_all();
+}
+
 bool TcpSocket::getBytes(char* buffer, size_t nItems) {
     waitForInput(nItems);
     if (_shouldStopThreads || (!_isConnected && !_isConnecting)) {

--- a/src/io/socket/websocket.cpp
+++ b/src/io/socket/websocket.cpp
@@ -162,6 +162,7 @@ void WebSocket::onClose(const websocketpp::connection_hdl& hdl) {
     const std::unique_lock lock(_connectionHandlesMutex);
     _connectionHandles.erase(hdl);
     _inputNotifier.notify_one();
+    _tcpSocket->closeConnection();
 }
 
 } // namespace ghoul::io

--- a/src/io/socket/websocket.cpp
+++ b/src/io/socket/websocket.cpp
@@ -82,7 +82,11 @@ WebSocket::WebSocket(std::unique_ptr<TcpSocket> socket,
                 _tcpSocket->put<char>(output.c_str(), output.size());
             }
             if (_isMarkedForClosing) {
-                _tcpSocket->waitForOuputQueueDrained();
+                const bool drained =
+                    _tcpSocket->waitForOutputQueueDrained(std::chrono::seconds(3));
+                if (!drained) {
+                    LWARNING("Timed out flushing final output before closing socket");
+                }
                 _tcpSocket->closeConnection();
             }
             _inputNotifier.notify_one();

--- a/src/io/socket/websocket.cpp
+++ b/src/io/socket/websocket.cpp
@@ -58,17 +58,29 @@ WebSocket::WebSocket(std::unique_ptr<TcpSocket> socket,
 
      _tcpSocket->interceptInput(
         [this](const char* data, size_t nBytes) {
-            _socketConnection->read_some(data, nBytes);
+            std::string output;
+            {
+                // Guards _socketConnection/_outputStream against putMessage() on other
+                // threads. onOpen/onMessage/onClose run nested inside read_some(), so
+                // they must not lock _outputStreamMutex themselves
+                const std::unique_lock lock(_outputStreamMutex);
+                _socketConnection->read_some(data, nBytes);
 
-            // `read_some` can cause the websocketpp to generate protocol-level output
-            // e.g., a Close frame response, or a Pong reply to a Ping. We need to send
-            // those responses back to the client so they are not kept waiting forever
-            const std::string output = _outputStream.str();
-            if (!output.empty()) {
-                _tcpSocket->put<char>(output.c_str(), output.size());
-                _outputStream.str("");
+
+                // `read_some` can cause the websocketpp to generate protocol-level output
+                // e.g., a Close frame response, or a Pong reply to a Ping. Flush the
+                // responses so the client isn't left waiting
+                output = _outputStream.str();
+                if (!output.empty()) {
+                    _outputStream.str("");
+                    _outputStream.clear();
+                }
             }
 
+            // Write outside the lock, since TcpSocket::put has its own internal locking
+            if (!output.empty()) {
+                _tcpSocket->put<char>(output.c_str(), output.size());
+            }
             _inputNotifier.notify_one();
         }
     );
@@ -76,6 +88,7 @@ WebSocket::WebSocket(std::unique_ptr<TcpSocket> socket,
 
 WebSocket::~WebSocket() {
     LDEBUG("Destroying socket connection");
+    _tcpSocket->uninterceptInput();
     _socketConnection->eof();
     _tcpSocket = nullptr;
 }
@@ -115,9 +128,22 @@ bool WebSocket::getMessage(std::string& message) {
 }
 
 bool WebSocket::putMessage(const std::string& message) {
-    _socketConnection->send(message);
-    _tcpSocket->put<char>(_outputStream.str().c_str(), _outputStream.str().size());
-    _outputStream.str("");
+    std::string output;
+
+    {
+        const std::unique_lock lock(_outputStreamMutex);
+        _socketConnection->send(message);
+        output = _outputStream.str();
+        if (!output.empty()) {
+            _outputStream.str("");
+            _outputStream.clear();
+        }
+
+    }
+
+    if (!output.empty()) {
+        _tcpSocket->put<char>(output.c_str(), output.size());
+    }
     return true;
 }
 
@@ -149,8 +175,6 @@ void WebSocket::onOpen(const websocketpp::connection_hdl& hdl) {
     ));
     const std::unique_lock lock(_connectionHandlesMutex);
     _connectionHandles.insert(hdl);
-    _tcpSocket->put<char>(_outputStream.str().c_str(), _outputStream.str().size());
-    _outputStream.str("");
 }
 
 void WebSocket::onClose(const websocketpp::connection_hdl& hdl) {

--- a/src/io/socket/websocket.cpp
+++ b/src/io/socket/websocket.cpp
@@ -59,6 +59,16 @@ WebSocket::WebSocket(std::unique_ptr<TcpSocket> socket,
      _tcpSocket->interceptInput(
         [this](const char* data, size_t nBytes) {
             _socketConnection->read_some(data, nBytes);
+
+            // `read_some` can cause the websocketpp to generate protocol-level output
+            // e.g., a Close frame response, or a Pong reply to a Ping. We need to send
+            // those responses back to the client so they are not kept waiting forever
+            const std::string output = _outputStream.str();
+            if (!output.empty()) {
+                _tcpSocket->put<char>(output.c_str(), output.size());
+                _outputStream.str("");
+            }
+
             _inputNotifier.notify_one();
         }
     );

--- a/src/io/socket/websocket.cpp
+++ b/src/io/socket/websocket.cpp
@@ -81,6 +81,10 @@ WebSocket::WebSocket(std::unique_ptr<TcpSocket> socket,
             if (!output.empty()) {
                 _tcpSocket->put<char>(output.c_str(), output.size());
             }
+            if (_isMarkedForClosing) {
+                _tcpSocket->waitForOuputQueueDrained();
+                _tcpSocket->closeConnection();
+            }
             _inputNotifier.notify_one();
         }
     );
@@ -186,7 +190,7 @@ void WebSocket::onClose(const websocketpp::connection_hdl& hdl) {
     const std::unique_lock lock(_connectionHandlesMutex);
     _connectionHandles.erase(hdl);
     _inputNotifier.notify_one();
-    _tcpSocket->closeConnection();
+    _isMarkedForClosing = true;
 }
 
 } // namespace ghoul::io

--- a/src/io/socket/websocket.cpp
+++ b/src/io/socket/websocket.cpp
@@ -66,7 +66,6 @@ WebSocket::WebSocket(std::unique_ptr<TcpSocket> socket,
                 const std::unique_lock lock(_outputStreamMutex);
                 _socketConnection->read_some(data, nBytes);
 
-
                 // `read_some` can cause the websocketpp to generate protocol-level output
                 // e.g., a Close frame response, or a Pong reply to a Ping. Flush the
                 // responses so the client isn't left waiting
@@ -84,6 +83,7 @@ WebSocket::WebSocket(std::unique_ptr<TcpSocket> socket,
             if (_isMarkedForClosing) {
                 const bool drained =
                     _tcpSocket->waitForOutputQueueDrained(std::chrono::seconds(3));
+
                 if (!drained) {
                     LWARNING("Timed out flushing final output before closing socket");
                 }
@@ -146,9 +146,9 @@ bool WebSocket::putMessage(const std::string& message) {
             _outputStream.str("");
             _outputStream.clear();
         }
-
     }
 
+    // Write outside the lock, since TcpSocket::put has its own internal locking
     if (!output.empty()) {
         _tcpSocket->put<char>(output.c_str(), output.size());
     }


### PR DESCRIPTION
This PR fixes some networking issues where we did not previously send back a protocol response when needed, for example when a WebSocket disconnects. 

Ensure protocol-level WebSocket responses (Ping/Pong/Close, etc)
Fixes an issue where protocol-level WebSocket responses were not sent back to the connected peer, which could leave the peer waiting indefinitely for a response. For example, when using the OpenSpace API to disconnect, the API would not be notified that the connection has been terminated until 10-20 seconds later, when an internal ping fails.

Also fixes an additional issue: possible lingering sockets on our end if the handshake/tear-up is not complete by the peer.  

Ensure socket closes even if handshake close is not complete from peer
There was an issue where if the peer sends a WebSocket close frame, Ghoul would respond with the correct handshake (previous fix), but if the peer does not properly close the TCP socket, this could leave the OpenSpace socket connection open indefinitely(or until shutdown). This fix removes the socket regardless after receiving and sending the close frame